### PR TITLE
Only run cluster tests when deployment and cluster files are changed

### DIFF
--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -69,7 +69,7 @@ jobs:
            "internal/provider/resources/resource_deployment.go"
          )
          for file in "${FILES_TO_CHECK[@]}"; do
-           if git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep -q "$file"; then
+           if git diff --name-only ${{ github.base_ref }} ${{ github.head_ref }} | grep -q "$file"; then
              SKIP_TESTS="False"
              break
            fi

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -54,6 +54,26 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - run: go mod download
+      - name: Determine if expensive tests should run
+        if: github.event_name == 'pull_request'
+        run: |
+         echo "CHECKING FILES FOR SKIP LOGIC..."
+         SKIP_TESTS="True"
+         FILES_TO_CHECK: &files_to_check
+           - internal/provider/schemas/deployment.go
+           - internal/provider/schemas/cluster.go
+           - internal/provider/models/deployment.go
+           - internal/provider/models/cluster.go
+           - internal/provider/resources/resource_cluster.go
+           - internal/provider/resources/resource_cluster_test.go
+           - internal/provider/resources/resource_deployment.go
+         for file in *files_to_check; do
+           if git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep -q "$file"; then
+             SKIP_TESTS="False"
+             break
+           fi
+         done
+         echo "SKIP_CLUSTER_RESOURCE_TESTS=$SKIP_TESTS" >> $GITHUB_ENV
       - env:
           TF_ACC: "1"
           HYBRID_ORGANIZATION_API_TOKEN: ${{ secrets.DEV_HYBRID_ORGANIZATION_API_TOKEN }}
@@ -63,6 +83,7 @@ jobs:
           HYBRID_CLUSTER_ID: clnp86ly5000401ndagu20g81
           HYBRID_NODE_POOL_ID: clnp86ly5000301ndzfxz895w
           ASTRO_API_HOST: https://api.astronomer-dev.io
+          SKIP_CLUSTER_RESOURCE_TESTS: ${{ env.SKIP_CLUSTER_RESOURCE_TESTS }}
           TESTARGS: "-failfast"
         run: make testacc
 

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -59,15 +59,16 @@ jobs:
         run: |
          echo "CHECKING FILES FOR SKIP LOGIC..."
          SKIP_TESTS="True"
-         FILES_TO_CHECK: &files_to_check
-           - internal/provider/schemas/deployment.go
-           - internal/provider/schemas/cluster.go
-           - internal/provider/models/deployment.go
-           - internal/provider/models/cluster.go
-           - internal/provider/resources/resource_cluster.go
-           - internal/provider/resources/resource_cluster_test.go
-           - internal/provider/resources/resource_deployment.go
-         for file in *files_to_check; do
+         FILES_TO_CHECK=(
+           "internal/provider/schemas/deployment.go"
+           "internal/provider/schemas/cluster.go"
+           "internal/provider/models/deployment.go"
+           "internal/provider/models/cluster.go"
+           "internal/provider/resources/resource_cluster.go"
+           "internal/provider/resources/resource_cluster_test.go"
+           "internal/provider/resources/resource_deployment.go"
+         )
+         for file in "${FILES_TO_CHECK[@]}"; do
            if git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep -q "$file"; then
              SKIP_TESTS="False"
              break


### PR DESCRIPTION
## Description
- dedicated cluster and deployment tests are expensive and take a long time
- we shouldn't run them for PRs if certain files are not changed
- they will still run when the PR is merged to main
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
https://github.com/astronomer/terraform-provider-astro/issues/37
## 🧪 Functional Testing
- GH action workflow works as expected
<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/)
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
