### PR TITLE
Add stage and dev CI workflows periodically

### DIFF
--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -111,6 +111,8 @@ jobs:
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
+          repository: astronomer/terraform-provider-astro
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ matrix.provider_version }}
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
@@ -151,6 +153,8 @@ jobs:
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
+          repository: astronomer/terraform-provider-astro
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ matrix.provider_version }}
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -11,6 +11,10 @@ on:
       - main
     paths-ignore:
       - 'README.md'
+  schedule:
+    - cron: '21 30 * * MON'  # Runs every Monday at 2:30PST for stage environment
+    - cron: '21 30 * * TUE'  # Runs every Tuesday at 2:30PST for dev environment
+    - cron: '21 30 * * FRI'  # Runs every Friday at 2:30PST for dev environment
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -90,3 +94,82 @@ jobs:
           TESTARGS: "-failfast"
         run: make testacc
 
+  testacc-stage:
+    # This job runs every Monday.
+    name: Terraform Provider Acceptance Tests - Stage
+    needs: build
+    if: github.event_name == 'schedule' && github.event.schedule == 'cron(21 30 * * MON)'
+    timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
+    strategy:
+      fail-fast: true
+      matrix:
+        terraform:
+          - latest
+        provider_version:
+          - latest
+          - main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          ref: ${{ matrix.provider_version }}
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          HYBRID_ORGANIZATION_API_TOKEN: ${{ secrets.STAGE_HYBRID_ORGANIZATION_API_TOKEN }}
+          HYBRID_ORGANIZATION_ID: ckon5obsu03322822nvm6yumk
+          HOSTED_ORGANIZATION_API_TOKEN: ${{ secrets.STAGE_HOSTED_ORGANIZATION_API_TOKEN }}
+          HOSTED_ORGANIZATION_ID: clczfo8a111cz0t140nck8ubn
+          HYBRID_CLUSTER_ID: clqqongl40fmv01m96dvxh2nu
+          HYBRID_NODE_POOL_ID: clqqongl40fmu01m94pwp4kct
+          ASTRO_API_HOST: https://api.astronomer-stage.io
+          TESTARGS: "-failfast"
+        run: make testacc
+
+  testacc-dev:
+    # This job runs every Friday and Tuesday.
+    name: Terraform Provider Acceptance Tests - Dev
+    needs: build
+    if: github.event_name == 'schedule' && (github.event.schedule == 'cron(21 30 * * FRI)' || github.event.schedule == 'cron(21 30 * * TUE)')
+    timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
+    strategy:
+      fail-fast: true
+      matrix:
+        terraform:
+          - latest
+        provider_version:
+          - latest
+          - main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          ref: ${{ matrix.provider_version }}
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          HYBRID_ORGANIZATION_API_TOKEN: ${{ secrets.DEV_HYBRID_ORGANIZATION_API_TOKEN }}
+          HYBRID_ORGANIZATION_ID: ckmzjm22937931d35puw3tcdo
+          HOSTED_ORGANIZATION_API_TOKEN: ${{ secrets.DEV_HOSTED_ORGANIZATION_API_TOKEN }}
+          HOSTED_ORGANIZATION_ID: clczfgzc3001o01kjlphpi6hv
+          HYBRID_CLUSTER_ID: clnp86ly5000401ndagu20g81
+          HYBRID_NODE_POOL_ID: clnp86ly5000301ndzfxz895w
+          ASTRO_API_HOST: https://api.astronomer-dev.io
+          TESTARGS: "-failfast"
+        run: make testacc

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -12,7 +12,7 @@ on:
     paths-ignore:
       - 'README.md'
   schedule:
-    - cron: '30 21 * * 1'  # Runs every Monday at 2:30PST for stage environment
+    - cron: '55 6 * * 5'  # Runs every Monday at 2:30PST for stage environment
     - cron: '30 21 * * 2,5'  # Runs every Tuesday and Friday at 2:30PST for dev environment
 
 # Testing only needs permissions to read the repository contents.
@@ -97,7 +97,7 @@ jobs:
     # This job runs every Monday.
     name: Terraform Provider Acceptance Tests - Stage
     needs: build
-    if: github.event_name == 'schedule' && github.event.schedule == 'cron(30 21 * * 1)'
+    if: github.event_name == 'schedule' && github.event.schedule == 'cron(55 6 * * 5)'
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
     strategy:
       fail-fast: true
@@ -137,7 +137,7 @@ jobs:
     # This job runs every Friday and Tuesday.
     name: Terraform Provider Acceptance Tests - Dev
     needs: build
-    if: github.event_name == 'schedule' && (github.event.schedule == 'cron(30 21 * * 2,5)')
+    if: github.event_name == 'schedule' && (github.event.schedule == 'cron(55 6 * * 5)')
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
     strategy:
       fail-fast: true

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -12,7 +12,7 @@ on:
     paths-ignore:
       - 'README.md'
   schedule:
-    - cron: '55 6 * * 5'  # Runs every Monday at 2:30PST for stage environment
+    - cron: '30 21 * * 1'  # Runs every Monday at 2:30PST for stage environment
     - cron: '30 21 * * 2,5'  # Runs every Tuesday and Friday at 2:30PST for dev environment
 
 # Testing only needs permissions to read the repository contents.
@@ -97,7 +97,7 @@ jobs:
     # This job runs every Monday.
     name: Terraform Provider Acceptance Tests - Stage
     needs: build
-    if: github.event_name == 'schedule' && github.event.schedule == 'cron(55 6 * * 5)'
+#    if: github.event_name == 'schedule' && github.event.schedule == 'cron(30 21 * * 1)'
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
     strategy:
       fail-fast: true
@@ -137,7 +137,7 @@ jobs:
     # This job runs every Friday and Tuesday.
     name: Terraform Provider Acceptance Tests - Dev
     needs: build
-    if: github.event_name == 'schedule' && (github.event.schedule == 'cron(55 6 * * 5)')
+    if: github.event_name == 'schedule' && (github.event.schedule == 'cron(30 21 * * 2,5)')
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
     strategy:
       fail-fast: true

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -97,7 +97,7 @@ jobs:
     # This job runs every Monday.
     name: Terraform Provider Acceptance Tests - Stage
     needs: build
-#    if: github.event_name == 'schedule' && github.event.schedule == 'cron(30 21 * * 1)'
+    if: github.event_name == 'schedule' && github.event.schedule == 'cron(30 21 * * 1)'
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
     strategy:
       fail-fast: true

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -105,14 +105,12 @@ jobs:
         terraform:
           - latest
         provider_version:
-          - latest
+          - v0.1.0-alpha
           - main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
-          repository: astronomer/terraform-provider-astro
-          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ matrix.provider_version }}
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
@@ -147,14 +145,12 @@ jobs:
         terraform:
           - latest
         provider_version:
-          - latest
+          - v0.1.0-alpha
           - main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
-          repository: astronomer/terraform-provider-astro
-          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ matrix.provider_version }}
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -12,9 +12,8 @@ on:
     paths-ignore:
       - 'README.md'
   schedule:
-    - cron: '21 30 * * MON'  # Runs every Monday at 2:30PST for stage environment
-    - cron: '21 30 * * TUE'  # Runs every Tuesday at 2:30PST for dev environment
-    - cron: '21 30 * * FRI'  # Runs every Friday at 2:30PST for dev environment
+    - cron: '30 21 * * 1'  # Runs every Monday at 2:30PST for stage environment
+    - cron: '30 21 * * 2,5'  # Runs every Tuesday and Friday at 2:30PST for dev environment
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -98,7 +97,7 @@ jobs:
     # This job runs every Monday.
     name: Terraform Provider Acceptance Tests - Stage
     needs: build
-    if: github.event_name == 'schedule' && github.event.schedule == 'cron(21 30 * * MON)'
+    if: github.event_name == 'schedule' && github.event.schedule == 'cron(30 21 * * 1)'
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
     strategy:
       fail-fast: true
@@ -138,7 +137,7 @@ jobs:
     # This job runs every Friday and Tuesday.
     name: Terraform Provider Acceptance Tests - Dev
     needs: build
-    if: github.event_name == 'schedule' && (github.event.schedule == 'cron(21 30 * * FRI)' || github.event.schedule == 'cron(21 30 * * TUE)')
+    if: github.event_name == 'schedule' && (github.event.schedule == 'cron(30 21 * * 2,5)')
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
     strategy:
       fail-fast: true

--- a/internal/provider/resources/resource_deployment_test.go
+++ b/internal/provider/resources/resource_deployment_test.go
@@ -103,10 +103,11 @@ func TestAcc_ResourceDeploymentHybrid(t *testing.T) {
 			},
 			// Import existing deployment and check it is correctly imported - https://stackoverflow.com/questions/68824711/how-can-i-test-terraform-import-in-acceptance-tests
 			{
-				ResourceName:            resourceVar,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"external_ips", "oidc_issuer_url"},
+				ResourceName:      resourceVar,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"external_ips", "oidc_issuer_url", "image_version", "scaling_status.hibernation_status.%",
+					"scaling_status.hibernation_status.is_hibernating", "scaling_status.hibernation_status.reason"},
 			},
 		},
 	})


### PR DESCRIPTION
## Description
- add stage and dev e2e tests that run periodically to watch for regressions in astro platform
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
https://github.com/astronomer/terraform-provider-astro/issues/24
## 🧪 Functional Testing
Stage tests for example: 
- https://github.com/astronomer/terraform-provider-astro/actions/runs/9124462775/job/25123161466
- https://github.com/astronomer/terraform-provider-astro/actions/runs/9124462775/job/25123161840
<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/)
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
