### PR TITLE
Add gpg signing to release GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,19 +24,17 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-# Comment out for now until we have a GPG key to use for public release
-#      - name: Import GPG key
-#        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
-#        id: import_gpg
-#        with:
-#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-#          passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
-          args: release --clean ${{ env.SIGNING_DISABLED == 'true' && '--skip sign' }}
+          args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          SIGNING_DISABLED: 'true'


### PR DESCRIPTION
## Description
- this is needed so that our terraform provider is gpg-signed/verified on the terraform registry
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
#19
## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Rebased from the main (or release if patching) branch (before testing)
- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/)
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
