### PR TITLE
Fix bug when setting null scaling spec on update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,9 +14,6 @@
 
 ## 📋 Checklist
 
-- [ ] Rebased from the main (or release if patching) branch (before testing)
 - [ ] Added/updated applicable tests
 - [ ] Added/updated examples in the `examples/` directory
-- [ ] Tested against [Astro-API](https://github.com/astronomer/astro/)
-- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
 - [ ] Updated any related [documentation](https://github.com/astronomer/docs/)

--- a/internal/provider/resources/resource_deployment.go
+++ b/internal/provider/resources/resource_deployment.go
@@ -960,8 +960,8 @@ func validateClusterIdConfig(ctx context.Context, data *models.DeploymentResourc
 // RequestScalingSpec converts a Terraform object to a platform.DeploymentScalingSpecRequest to be used in create and update requests
 func RequestScalingSpec(ctx context.Context, scalingSpecObj types.Object) (*platform.DeploymentScalingSpecRequest, diag.Diagnostics) {
 	if scalingSpecObj.IsNull() {
-		// If the scaling spec is not set, return nil for the request
-		return nil, nil
+		// If the scaling spec is not set, return an empty scaling spec for the request
+		return &platform.DeploymentScalingSpecRequest{}, nil
 	}
 	var scalingSpec models.DeploymentScalingSpec
 	diags := scalingSpecObj.As(ctx, &scalingSpec, basetypes.ObjectAsOptions{

--- a/internal/provider/resources/resource_deployment_test.go
+++ b/internal/provider/resources/resource_deployment_test.go
@@ -441,9 +441,9 @@ func TestAcc_ResourceDeploymentStandardScalingSpec(t *testing.T) {
 			// Make scaling spec null to test that it is removed from the deployment with no errors
 			{
 				Config: astronomerprovider.ProviderConfig(t, true) + developmentDeployment(scalingSpecDeploymentName,
-					``),
+					` `),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(scalingSpecResourceVar, "scaling_spec"),
+					resource.TestCheckResourceAttr(scalingSpecResourceVar, "scaling_spec.%", "0"),
 				),
 			},
 			{

--- a/internal/provider/resources/resource_deployment_test.go
+++ b/internal/provider/resources/resource_deployment_test.go
@@ -438,6 +438,14 @@ func TestAcc_ResourceDeploymentStandardScalingSpec(t *testing.T) {
 					resource.TestCheckNoResourceAttr(scalingSpecResourceVar, "scaling_spec.hibernation_spec.schedules"),
 				),
 			},
+			// Make scaling spec null to test that it is removed from the deployment with no errors
+			{
+				Config: astronomerprovider.ProviderConfig(t, true) + developmentDeployment(scalingSpecDeploymentName,
+					``),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(scalingSpecResourceVar, "scaling_spec"),
+				),
+			},
 			{
 				Config: astronomerprovider.ProviderConfig(t, true) + developmentDeployment(scalingSpecDeploymentName,
 					`scaling_spec = {


### PR DESCRIPTION
## Description
- when updating a deployment that has a scaling spec to one that doesnt, there were terraform provider errors
- this PR fixes them by setting an empty ScalingSpecRequest. Previously, a null ScalingSpecRequest sent to the API server meant to not update the scaling spec but what we actually want is to remove the scaling spec.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
n/a
## 🧪 Functional Testing
- added to acceptance tests
- tested manually
<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch (before testing)
- [x] Added/updated applicable tests
- [x] Added/updated examples in the `examples/` directory
- [x] Tested against [Astro-API](https://github.com/astronomer/astro/)
- [x] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
