### PR TITLE
Downgrade go releaser to previous working version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,10 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+        uses: goreleaser/goreleaser-action@v6
         with:
+          distribution: goreleaser
+          version: '~> v2'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
           version: '~> v2'
           args: release --clean
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,8 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
-          version: '~> v2'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -42,7 +42,6 @@ jobs:
         # list whatever Terraform versions here you would like to support
         terraform:
           - latest
-#          - '1.7.*'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
@@ -105,6 +104,8 @@ jobs:
         terraform:
           - latest
         provider_version:
+          - v0.3.0
+          - v0.2.1
           - v0.1.0-alpha
           - main
     runs-on: ubuntu-latest
@@ -147,6 +148,8 @@ jobs:
         terraform:
           - latest
         provider_version:
+          - v0.3.0
+          - v0.2.1
           - v0.1.0-alpha
           - main
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Tried fixing forward by updating goreleaser but it didn't work so just going to downgrade to a known working version
Also updated the provider versions to test the last 3 versions of the terraform provider against dev and stage.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)

## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
