### PR TITLE
Add guard for invalid deploymentId in team creation

### DIFF
--- a/internal/provider/common/role.go
+++ b/internal/provider/common/role.go
@@ -128,8 +128,7 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 		tflog.Error(ctx, "failed to mutate roles")
 		return diag.Diagnostics{diag.NewErrorDiagnostic(
 			"Unable to mutate roles, not every deployment role has a corresponding valid deployment",
-			//fmt.Sprintf("Please ensure that every deployment role has a corresponding deployment, got invalid deployment ids: %v", invalidDeploymentIds),
-			fmt.Sprintf("Please ensure that every deployment role has a corresponding deployment, got invalid deployment ids: %v, deploymentRoleIds: %v, deploymentIds: %v, listdeployments: %v", invalidDeploymentIds, deploymentRoleIds, deploymentIds, listDeployments.JSON200.Deployments),
+			fmt.Sprintf("Please ensure that every deployment role has a corresponding deployment, got invalid deployment ids: %v", invalidDeploymentIds),
 		),
 		}
 	}
@@ -140,7 +139,7 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 	})
 	deploymentWorkspaceIds = lo.Uniq(deploymentWorkspaceIds)
 
-	// get list of workspaceRoleIds
+	// get list of workspaceRole ids
 	workspaceRoleIds := lo.Map(input.WorkspaceRoles, func(role iam.WorkspaceRole, _ int) string {
 		return role.WorkspaceId
 	})


### PR DESCRIPTION
## Description

Adds a guard checking for invalid deployment ids in team deployment roles during creation. deletes the team if any errors are found.

<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)

Based off of error here: https://github.com/astronomer/astro/issues/23585

## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
