### PR TITLE
Hybrid celery example usage

### DIFF
--- a/examples/resources/astro_deployment/resource.tf
+++ b/examples/resources/astro_deployment/resource.tf
@@ -74,6 +74,34 @@ resource "astro_deployment" "hybrid" {
   }]
 }
 
+resource "astro_deployment" "hybrid_celery" {
+  original_astro_runtime_version = "11.3.0"
+  name                           = "my hybrid celery deployment"
+  description                    = "an example deployment with celery executor"
+  type                           = "HYBRID"
+  cluster_id                     = "clnp86ly5000401ndagu20g81"
+  contact_emails                 = ["example@astronomer.io"]
+  executor                       = "CELERY"
+  is_cicd_enforced               = true
+  is_dag_deploy_enabled          = true
+  scheduler_replicas             = 1
+  scheduler_au                   = 5
+  workspace_id                   = "clnp86ly5000401ndaga20g81"
+  environment_variables = [{
+    key       = "key1"
+    value     = "value1"
+    is_secret = false
+  }]
+  worker_queues = [{
+    name               = "default"
+    is_default         = true
+    node_pool_id       = "clnp86ly5000301ndzfxz895w"
+    max_worker_count   = 10
+    min_worker_count   = 0
+    worker_concurrency = 1
+  }]
+}
+
 // Import an existing deployment
 import {
   id = "clv17vgft000801kkydsws63x" // ID of the existing deployment

--- a/internal/provider/schemas/deployment.go
+++ b/internal/provider/schemas/deployment.go
@@ -214,7 +214,7 @@ func DeploymentResourceSchemaAttributes() map[string]resourceSchema.Attribute {
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: WorkerQueueResourceSchemaAttributes(),
 			},
-			MarkdownDescription: "Deployment worker queues - required for deployments with 'CELERY' executor",
+			MarkdownDescription: "Deployment worker queues - required for deployments with 'CELERY' executor. For 'STANDARD' and 'DEDICATED' deployments, use astro_machine. For 'HYBRID' deployments, use node_pool_id.",
 			Validators: []validator.Set{
 				// Dynamic validation with 'executor' done in the resource.ValidateConfig function
 				setvalidator.SizeAtLeast(1),


### PR DESCRIPTION
## Description
HYBRID example usage for CELERY is missing and it needs node_pool_id.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
NA
## 🧪 Functional Testing
NA
<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots
NA
<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [x] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)

> Didn't updated the docs. I guess they are supposed to be autogenerated using `tfplugindocs generate` ??
