### PR TITLE
Allow scaling spec to be set dynamically

### DIFF
--- a/internal/provider/resources/resource_deployment.go
+++ b/internal/provider/resources/resource_deployment.go
@@ -902,13 +902,6 @@ func validateHostedConfig(ctx context.Context, data *models.DeploymentResource) 
 			tflog.Error(ctx, "failed to convert hibernation spec", map[string]interface{}{"error": diags})
 			return diags
 		}
-		if hibernationSpec.Override.IsNull() && hibernationSpec.Schedules.IsNull() {
-			diags.AddError(
-				"scaling_spec (hibernation) must have either override or schedules",
-				"Please provide either override or schedules in 'scaling_spec.hibernation_spec'",
-			)
-			return diags
-		}
 	}
 
 	// Need to check worker_queues for hosted deployments have `astro_machine` and do not have `node_pool_id`
@@ -1006,8 +999,8 @@ func RequestScalingSpec(ctx context.Context, scalingSpecObj types.Object) (*plat
 	platformScalingSpec.HibernationSpec = &platform.DeploymentHibernationSpecRequest{}
 
 	if hibernationSpec.Override.IsNull() && hibernationSpec.Schedules.IsNull() {
-		// If the hibernation spec is set but both override and schedules are not set, return an empty hibernation spec for the request
-		return platformScalingSpec, nil
+		// If the hibernation spec is set but both override and schedules are not set, return an error
+		return platformScalingSpec, diag.Diagnostics{diag.NewErrorDiagnostic("scaling_spec.hibernation_spec must have either override or schedules", "Please provide either override or schedules in 'scaling_spec.hibernation_spec")}
 	}
 	if !hibernationSpec.Override.IsNull() {
 		var override models.HibernationSpecOverride

--- a/internal/provider/resources/resource_deployment_test.go
+++ b/internal/provider/resources/resource_deployment_test.go
@@ -376,13 +376,6 @@ func TestAcc_ResourceDeploymentStandardScalingSpec(t *testing.T) {
 			},
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + developmentDeployment(scalingSpecDeploymentName,
-					`scaling_spec = {
-									hibernation_spec = {}
-								}`),
-				ExpectError: regexp.MustCompile(`scaling_spec \(hibernation\) must have either override or schedules`),
-			},
-			{
-				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + developmentDeployment(scalingSpecDeploymentName,
 					`
 						scaling_spec = {
 							hibernation_spec = {


### PR DESCRIPTION
## Description
User wants to determine scaling_spec via variable and using tertiary operator like the following
```
scaling_spec = var.environment_name != "prod" ? {
    hibernation_spec = {
      override = null
      schedules = [{
        is_enabled       = true
        hibernate_at_cron = "0 22 * * *"  
        wake_at_cron     = "0 14 * * *"  
      }]
    }
  } : null
```
However, it does not work with the current validation.
I had to move the validation to runtime instead, which seemed to fix it. Added some integration tests as well.
<!--- Describe the purpose of this pull request. --->

## 🧪 Functional Testing
Added some integration tests.
Did some manual testing with the following with
1. var.environment_name == "prod"
2. var.environment_name == "dev"
3. scaling_spec.hibernation_spec.override and scaling_spec.hibernation_spec.schedule, which passes `terraform plan` but fails `terraform apply` (expected new behavior)
```
resource "astro_deployment" "team_1_dev_deployment" {
  name                    = "team-1-dev-deployment"
  description             = "Team 1 Dev Deployment"
  type                    = "STANDARD"
  cloud_provider          = "AWS"
  region                  = "us-east-1"
  contact_emails          = []
  default_task_pod_cpu    = "0.25"
  default_task_pod_memory = "0.5Gi"
  executor                = "CELERY"
  is_cicd_enforced        = true
  is_dag_deploy_enabled   = true
  is_development_mode     = true
  is_high_availability    = false
  resource_quota_cpu      = "10"
  resource_quota_memory   = "20Gi"
  scheduler_size          = "SMALL"
  workspace_id            = astro_workspace.team_1_workspace.id
  environment_variables   = []
  worker_queues = [{
    name               = "default"
    is_default         = true
    astro_machine      = "A5"
    max_worker_count   = 10
    min_worker_count   = 0
    worker_concurrency = 1
  }]
  scaling_spec = var.environment_name != "prd" ? {
    hibernation_spec = {
      schedules = [{
        is_enabled       = true
        hibernate_at_cron = "0 22 * * *"
        wake_at_cron     = "0 14 * * *"
      }]
    }
  } : null
}


variable "environment_name" {
  type    = string
  default = "prod"
}
```

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📋 Checklist

- [x] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
