### PR TITLE
Allow dynamic isDevelopmentMode for deployment resource

### DIFF
--- a/internal/provider/resources/resource_deployment.go
+++ b/internal/provider/resources/resource_deployment.go
@@ -872,14 +872,6 @@ func validateHostedConfig(ctx context.Context, data *models.DeploymentResource) 
 		)
 	}
 
-	// Need to check that scaling_spec is only for is_development_mode set to true
-	if !data.IsDevelopmentMode.ValueBool() && !data.ScalingSpec.IsNull() {
-		diags.AddError(
-			"scaling_spec (hibernation) is only supported for is_development_mode set to true",
-			"Either set is_development_mode to true or remove scaling_spec",
-		)
-	}
-
 	// Need to check that scaling_spec has either override or schedules
 	if !data.ScalingSpec.IsNull() {
 		var scalingSpec models.DeploymentScalingSpec


### PR DESCRIPTION
## Description
Customer wants to use `isDevelopmentMode` dynamically like so:
```
resource "astro_deployment" "team_1_dev_deployment" {
#     original_astro_runtime_version = "11.3.0"
  name                    = "team-1-dev-deployment3"
  description             = "Team 1 Dev Deployment"
  type                    = "STANDARD"
  cloud_provider          = "AWS"
  region                  = "us-east-1"
  contact_emails          = []
  default_task_pod_cpu    = "0.25"
  default_task_pod_memory = "0.5Gi"
  executor                = "CELERY"
  is_cicd_enforced        = true
  is_dag_deploy_enabled   = true
  is_development_mode     = var.environment_name == "prd" ? true : false
  is_high_availability    = false
  resource_quota_cpu      = "10"
  resource_quota_memory   = "20Gi"
  scheduler_size          = "SMALL"
  workspace_id            = astro_workspace.team_1_workspace.id
  environment_variables   = []
  worker_queues = [{
    name               = "default"
    is_default         = true
    astro_machine      = "A5"
    max_worker_count   = 10
    min_worker_count   = 0
    worker_concurrency = 1
  }]
  scaling_spec = var.environment_name == "prd" ? null : {
    hibernation_spec = {
      schedules = [{
        hibernate_at_cron    = "1 * * * *"
        is_enabled           = true
        wake_at_cron         = "59 * * * *"
      }]
    }
  }
}


variable "environment_name" {
  type    = string
  default = "prd"
}
```

Our static validation does not allow this so I removed it.

<!--- Describe the purpose of this pull request. --->

## 🧪 Functional Testing
- Tested with isDevelopmentMode = [true, false] and scalingSpec = [null, <actual scaling spec>] 
- The only case that correctly fails is isDevelopmentMode=false and scalingSpec=<actual scaling spec>
<img width="865" alt="Screenshot 2024-11-19 at 3 35 51 PM" src="https://github.com/user-attachments/assets/e3a33111-22cb-4818-ba6c-3140a5ee6d9a">

- The other 3 cases correctly pass still
<img width="811" alt="Screenshot 2024-11-19 at 3 37 42 PM" src="https://github.com/user-attachments/assets/13fb1eae-73b2-4027-8fce-2883c983cf48">
- Note isDevelopment=true and scalingSpec=null is fine since users can update the scaling spec later

