### PR TITLE
Allow dynamic worker queue to be set

### DIFF
--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -212,8 +212,8 @@ func (r *ClusterResource) Create(
 
 	// Wait for the cluster to be created (or fail)
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{string(platform.ClusterStatusCREATING), string(platform.ClusterStatusUPDATING)},
-		Target:     []string{string(platform.ClusterStatusCREATED), string(platform.ClusterStatusUPDATEFAILED), string(platform.ClusterStatusCREATEFAILED)},
+		Pending:    []string{string(platform.ClusterStatusCREATING), string(platform.ClusterStatusUPDATING), string(platform.ClusterStatusUPGRADEPENDING)},
+		Target:     []string{string(platform.ClusterStatusCREATED), string(platform.ClusterStatusUPDATEFAILED), string(platform.ClusterStatusCREATEFAILED), string(platform.ClusterStatusACCESSDENIED)},
 		Refresh:    ClusterResourceRefreshFunc(ctx, r.platformClient, r.organizationId, cluster.JSON200.Id),
 		Timeout:    3 * time.Hour,
 		MinTimeout: 1 * time.Minute,
@@ -364,8 +364,8 @@ func (r *ClusterResource) Update(
 
 	// Wait for the cluster to be updated (or fail)
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{string(platform.ClusterStatusCREATING), string(platform.ClusterStatusUPDATING)},
-		Target:     []string{string(platform.ClusterStatusCREATED), string(platform.ClusterStatusUPDATEFAILED), string(platform.ClusterStatusCREATEFAILED)},
+		Pending:    []string{string(platform.ClusterStatusCREATING), string(platform.ClusterStatusUPDATING), string(platform.ClusterStatusUPGRADEPENDING)},
+		Target:     []string{string(platform.ClusterStatusCREATED), string(platform.ClusterStatusUPDATEFAILED), string(platform.ClusterStatusCREATEFAILED), string(platform.ClusterStatusACCESSDENIED)},
 		Refresh:    ClusterResourceRefreshFunc(ctx, r.platformClient, r.organizationId, cluster.JSON200.Id),
 		Timeout:    3 * time.Hour,
 		MinTimeout: 1 * time.Minute,
@@ -435,7 +435,7 @@ func (r *ClusterResource) Delete(
 
 	// Wait for the cluster to be deleted
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{string(platform.ClusterStatusCREATING), string(platform.ClusterStatusUPDATING), string(platform.ClusterStatusCREATED), string(platform.ClusterStatusUPDATEFAILED), string(platform.ClusterStatusCREATEFAILED)},
+		Pending:    []string{string(platform.ClusterStatusCREATING), string(platform.ClusterStatusUPDATING), string(platform.ClusterStatusCREATED), string(platform.ClusterStatusUPDATEFAILED), string(platform.ClusterStatusCREATEFAILED), string(platform.ClusterStatusUPGRADEPENDING)},
 		Target:     []string{"DELETED"},
 		Refresh:    ClusterResourceRefreshFunc(ctx, r.platformClient, r.organizationId, data.Id.ValueString()),
 		Timeout:    1 * time.Hour,

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -190,9 +190,10 @@ func TestAcc_ResourceClusterAwsWithDedicatedDeployments(t *testing.T) {
 			},
 			// Import existing cluster and check it is correctly imported - https://stackoverflow.com/questions/68824711/how-can-i-test-terraform-import-in-acceptance-tests
 			{
-				ResourceName:      awsResourceVar,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            awsResourceVar,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"health_status", "health_status.value"},
 			},
 		},
 	})

--- a/internal/provider/resources/resource_deployment.go
+++ b/internal/provider/resources/resource_deployment.go
@@ -645,20 +645,6 @@ func (r *DeploymentResource) ValidateConfig(
 		return
 	}
 
-	// Need to do dynamic validation based on the executor and worker queues
-	if data.Executor.ValueString() == string(platform.DeploymentExecutorKUBERNETES) && len(data.WorkerQueues.Elements()) > 0 {
-		resp.Diagnostics.AddError(
-			"worker_queues are not supported for 'KUBERNETES' executor",
-			"Either change the executor to 'CELERY' or remove worker_queues",
-		)
-	}
-	if data.Executor.ValueString() == string(platform.DeploymentExecutorCELERY) && (data.WorkerQueues.IsNull() || len(data.WorkerQueues.Elements()) == 0) {
-		resp.Diagnostics.AddError(
-			"worker_queues must be included for 'CELERY' executor",
-			"Either change the executor to 'KUBERNETES' or include worker_queues",
-		)
-	}
-
 	// Type specific validation
 	switch platform.DeploymentType(data.Type.ValueString()) {
 	case platform.DeploymentTypeSTANDARD:

--- a/internal/provider/resources/resource_deployment_test.go
+++ b/internal/provider/resources/resource_deployment_test.go
@@ -168,7 +168,7 @@ func TestAcc_ResourceDeploymentStandard(t *testing.T) {
 					Executor:                    "KUBERNETES",
 					SchedulerSize:               string(platform.SchedulerMachineNameSMALL),
 					IncludeEnvironmentVariables: true,
-					WorkerQueuesStr: 		   workerQueuesStr(""),
+					WorkerQueuesStr:             workerQueuesStr(""),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(awsResourceVar, "name", awsDeploymentName),
@@ -194,7 +194,7 @@ func TestAcc_ResourceDeploymentStandard(t *testing.T) {
 					Executor:                    "CELERY",
 					SchedulerSize:               string(platform.SchedulerMachineNameEXTRALARGE),
 					IncludeEnvironmentVariables: false,
-					WorkerQueuesStr: 		   workerQueuesStr(""),
+					WorkerQueuesStr:             workerQueuesStr(""),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(awsResourceVar, "description", utils.TestResourceDescription),
@@ -247,7 +247,7 @@ func TestAcc_ResourceDeploymentStandard(t *testing.T) {
 					Executor:                    "CELERY",
 					SchedulerSize:               string(platform.SchedulerMachineNameMEDIUM),
 					IncludeEnvironmentVariables: false,
-					WorkerQueuesStr: `worker_queues = lookup(local.worker_queue_config, var.env, local.worker_queue_config["default"])`
+					WorkerQueuesStr:             `worker_queues = lookup(local.worker_queue_config, var.env, local.worker_queue_config["default"])`,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(awsResourceVar, "executor", "CELERY"),
@@ -342,7 +342,7 @@ func TestAcc_ResourceDeploymentStandard(t *testing.T) {
 					Executor:                    "CELERY",
 					SchedulerSize:               string(platform.SchedulerMachineNameSMALL),
 					IncludeEnvironmentVariables: true,
-					WorkerQueuesStr: 		   workerQueuesStr(""),
+					WorkerQueuesStr:             workerQueuesStr(""),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(azureCeleryResourceVar, "name", azureCeleryDeploymentName),
@@ -777,7 +777,7 @@ func developmentDeployment(scalingSpecDeploymentName, scalingSpec string) string
 		SchedulerSize:     string(platform.SchedulerMachineNameSMALL),
 		IsDevelopmentMode: true,
 		ScalingSpec:       scalingSpec,
-		WorkerQueuesStr: 		   workerQueuesStr(""),
+		WorkerQueuesStr:   workerQueuesStr(""),
 	})
 }
 

--- a/internal/provider/resources/resource_deployment_test.go
+++ b/internal/provider/resources/resource_deployment_test.go
@@ -168,7 +168,6 @@ func TestAcc_ResourceDeploymentStandard(t *testing.T) {
 					Executor:                    "KUBERNETES",
 					SchedulerSize:               string(platform.SchedulerMachineNameSMALL),
 					IncludeEnvironmentVariables: true,
-					WorkerQueuesStr:             workerQueuesStr(""),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(awsResourceVar, "name", awsDeploymentName),

--- a/internal/provider/resources/resource_team_roles_test.go
+++ b/internal/provider/resources/resource_team_roles_test.go
@@ -67,6 +67,7 @@ func TestAcc_ResourceTeamRoles(t *testing.T) {
 						IncludeEnvironmentVariables: false,
 						SchedulerSize:               string(platform.DeploymentSchedulerSizeSMALL),
 						IsDevelopmentMode:           false,
+						WorkerQueuesStr:             workerQueuesStr(""),
 					}) +
 					teamRoles(string(iam.ORGANIZATIONMEMBER),
 						fmt.Sprintf(`[{workspace_id = %s


### PR DESCRIPTION
## Description

<!--- Describe the purpose of this pull request. --->

## 🧪 Functional Testing
Tested with this script
```
variable "env" {
  type = string
  default = "prod"
}

locals {
  worker_queue_config = {
    dev = [
      {
        name               = "default"
        is_default         = true
        astro_machine      = "A5"
        max_worker_count   = 10
        min_worker_count   = 0
        worker_concurrency = 5
      }
    ]
    default = [
      {
        name               = "default"
        is_default         = false
        astro_machine      = "A10"
        max_worker_count   = 3
        min_worker_count   = 1
        worker_concurrency = 10
      }
    ]
  }
}


resource "astro_deployment" "dedicated" {
  name                           = "test-wq-deployment"
  description                    = "Test deployment"
  type                           = "STANDARD"
  region                         = "us-east-1"
    cloud_provider               = "AWS"
  contact_emails                 = ["vandy.liu@astronomer.io"]
  default_task_pod_cpu           = "0.25"
  default_task_pod_memory        = "0.5Gi"
  executor                       = "CELERY"
  is_cicd_enforced               = false
  is_dag_deploy_enabled          = true
  is_development_mode            = true
  is_high_availability           = false
  resource_quota_cpu             = "10"
  resource_quota_memory          = "20Gi"
  scheduler_size                 = "SMALL"
  workspace_id                   = "cm4rl55w8000501ghao8mnkwd"
  environment_variables          = []
  worker_queues                  = lookup(local.worker_queue_config, var.env, local.worker_queue_config["default"])
}
```

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots
![Screenshot 2024-12-16 at 2 09 11 PM](https://github.com/user-attachments/assets/23481969-dba9-4a9f-8cc8-71bcb7e75c92)

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
