### PR TITLE
Remove ValidateConfig from resource team and resource user roles

### DIFF
--- a/internal/provider/resources/resource_team_test.go
+++ b/internal/provider/resources/resource_team_test.go
@@ -74,7 +74,7 @@ func TestAcc_ResourceTeam(t *testing.T) {
 						},
 					},
 				}),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("Role '%s' is not valid for role type '%s'", string(iam.ORGANIZATIONOWNER), string(iam.WORKSPACE))),
+				ExpectError: regexp.MustCompile(".*value must be one of.*"),
 			},
 			// Test failure: check for missing corresponding workspace role if deployment role is present
 			{

--- a/internal/provider/resources/resource_team_test.go
+++ b/internal/provider/resources/resource_team_test.go
@@ -74,7 +74,7 @@ func TestAcc_ResourceTeam(t *testing.T) {
 						},
 					},
 				}),
-				ExpectError: regexp.MustCompile(".*value must be one of.*"),
+				ExpectError: regexp.MustCompile(".*Invalid Attribute Value Match.*"),
 			},
 			// Test failure: check for missing corresponding workspace role if deployment role is present
 			{

--- a/internal/provider/resources/resource_user_roles.go
+++ b/internal/provider/resources/resource_user_roles.go
@@ -96,6 +96,11 @@ func (r *UserRolesResource) MutateRoles(
 	}
 
 	// Validate the roles
+	diags = common.ValidateRoles(workspaceRoles, deploymentRoles)
+	if diags.HasError() {
+		return diags
+	}
+
 	diags = common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 		PlatformClient:  r.platformClient,
 		OrganizationId:  r.organizationId,
@@ -310,69 +315,4 @@ func (r *UserRolesResource) ImportState(
 	resp *resource.ImportStateResponse,
 ) {
 	resource.ImportStatePassthroughID(ctx, path.Root("user_id"), req, resp)
-}
-
-func (r *UserRolesResource) ValidateConfig(
-	ctx context.Context,
-	req resource.ValidateConfigRequest,
-	resp *resource.ValidateConfigResponse,
-) {
-	var data models.UserRoles
-
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Validate workspace roles
-	workspaceRoles, diags := common.RequestWorkspaceRoles(ctx, data.WorkspaceRoles)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	for _, role := range workspaceRoles {
-		if !common.ValidateRoleMatchesEntityType(string(role.Role), string(iam.WORKSPACE)) {
-			resp.Diagnostics.AddError(
-				fmt.Sprintf("Role '%s' is not valid for role type '%s'", string(role.Role), string(iam.WORKSPACE)),
-				fmt.Sprintf("Please provide a valid role for the type '%s'", string(iam.WORKSPACE)),
-			)
-			return
-		}
-	}
-
-	duplicateWorkspaceIds := common.GetDuplicateWorkspaceIds(workspaceRoles)
-	if len(duplicateWorkspaceIds) > 0 {
-		resp.Diagnostics.AddError(
-			"Invalid Configuration: Cannot have multiple roles with the same workspace id",
-			fmt.Sprintf("Please provide a unique workspace id for each role. The following workspace ids are duplicated: %v", duplicateWorkspaceIds),
-		)
-		return
-	}
-
-	// Validate deployment roles
-	deploymentRoles, diags := common.RequestDeploymentRoles(ctx, data.DeploymentRoles)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	for _, role := range deploymentRoles {
-		if !common.ValidateRoleMatchesEntityType(role.Role, string(iam.DEPLOYMENT)) {
-			resp.Diagnostics.AddError(
-				fmt.Sprintf("Role '%s' is not valid for role type '%s'", role.Role, string(iam.DEPLOYMENT)),
-				fmt.Sprintf("Please provide a valid role for the type '%s'", string(iam.DEPLOYMENT)),
-			)
-			return
-		}
-	}
-
-	duplicateDeploymentIds := common.GetDuplicateDeploymentIds(deploymentRoles)
-	if len(duplicateDeploymentIds) > 0 {
-		resp.Diagnostics.AddError(
-			"Invalid Configuration: Cannot have multiple roles with the same deployment id",
-			fmt.Sprintf("Please provide unique deployment id for each role. The following deployment ids are duplicated: %v", duplicateDeploymentIds),
-		)
-		return
-	}
 }

--- a/internal/provider/resources/resource_user_roles_test.go
+++ b/internal/provider/resources/resource_user_roles_test.go
@@ -40,7 +40,7 @@ func TestAcc_ResourceUserRoles(t *testing.T) {
 							},
 						},
 					}),
-				ExpectError: regexp.MustCompile(fmt.Sprintf("Role '%s' is not valid for role type '%s'", string(iam.ORGANIZATIONOWNER), string(iam.WORKSPACE))),
+				ExpectError: regexp.MustCompile(".*Invalid Attribute Value Match.*"),
 			},
 			// Test failure: check for missing corresponding workspace role if deployment role is present
 			{


### PR DESCRIPTION
## Description
- Remove ValidateConfig so we can use these resources with `for_each`
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
https://github.com/astronomer/terraform-provider-astro/issues/185
## 🧪 Functional Testing
- tests all still pass
- cannot use for_each in the tests since it is not supported
<!--- List the functional testing steps to confirm this feature or fix. --->

Tested manually with 
```

locals {
  deployment_tokens = {
    admin = "DEPLOYMENT_ADMIN"
  }
  user_details = {
    vandy = {
      user_id = "cllyk67v7003x01nz07te40bn"
      email = "vandy.liu@astronomer.io"
      role = "ORGANIZATION_OWNER"
      ws_role = "WORKSPACE_OWNER"
    }
  }
}

resource "astro_user_roles" "user_role_setting" {
  for_each = local.user_details

  user_id = each.value.user_id
  organization_role = each.value.role
  workspace_roles = [
    {
      workspace_id = "cm4rl55w8000501ghao8mnkwd"
      role = each.value.ws_role
    }
  ]
}
```

## 📸 Screenshots
### AFTER
![Screenshot 2025-01-13 at 9 41 19 AM](https://github.com/user-attachments/assets/a3be1a2c-a141-4e2d-acdb-329fc50ce4b4)


### BEFORE
![Screenshot 2025-01-13 at 9 39 06 AM](https://github.com/user-attachments/assets/b78dd192-6823-4667-baa2-21bf738af526)

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [x] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
