### PR TITLE
Update terraform import script to include alert and notification channel

### DIFF
--- a/import/import_script.go
+++ b/import/import_script.go
@@ -147,8 +147,8 @@ provider "astro" {
 		"team":                 handleTeams,
 		"team_roles":           handleTeamRoles,
 		"user_roles":           handleUserRoles,
-		"alert":                handleAlert,
-		"notification_channel": handleNotificationChannel,
+		"alert":                handleAlerts,
+		"notification_channel": handleNotificationChannels,
 	}
 
 	results := make(chan HandlerResult, len(resources))
@@ -744,7 +744,7 @@ import {
 	return importString, nil
 }
 
-func handleAlert(ctx context.Context, platformClient *platform.ClientWithResponses, iamClient *iam.ClientWithResponses, organizationId string) (string, error) {
+func handleAlerts(ctx context.Context, platformClient *platform.ClientWithResponses, iamClient *iam.ClientWithResponses, organizationId string) (string, error) {
 	log.Printf("Importing alerts for organization %s", organizationId)
 
 	alertsResp, err := platformClient.ListAlertsWithResponse(ctx, organizationId, &platform.ListAlertsParams{Limit: lo.ToPtr(1000)})
@@ -816,7 +816,7 @@ import {
 	return importString, nil
 }
 
-func handleNotificationChannel(ctx context.Context, platformClient *platform.ClientWithResponses, iamClient *iam.ClientWithResponses, organizationId string) (string, error) {
+func handleNotificationChannels(ctx context.Context, platformClient *platform.ClientWithResponses, iamClient *iam.ClientWithResponses, organizationId string) (string, error) {
 	log.Printf("Importing notification channels for organization %s", organizationId)
 
 	notificationChannelsResp, err := platformClient.ListNotificationChannelsWithResponse(ctx, organizationId, &platform.ListNotificationChannelsParams{Limit: lo.ToPtr(1000)})


### PR DESCRIPTION
## Description

This PR updates Terraform Import Script to add Alert and Notification Channel. Users will be able to import their Astro Alerts and Notification Channels and manage it through Terraform.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)

#233 

## 🧪 Functional Testing
- Added new unit tests for Alert and Notification Channel

## Import Script Tests:
### Alert
**DAG Failure**
```
# __generated__ by Terraform from "cmcxzcwfn01on01lmz0s3w90r"
resource "astro_alert" "alert_cmcxzcwfn01on01lmz0s3w90r" {
  entity_id                = "cm1zkps2a0cv301ph39benet6"
  entity_type              = "DEPLOYMENT"
  name                     = "DAG Failure Alert"
  notification_channel_ids = ["cm4nwrvyg024h01mk2dn58m5s"]
  rules = {
    pattern_matches = [
      {
        entity_type   = "DAG_ID"
        operator_type = "IS"
        values        = ["*", "test"]
      },
    ]
    properties = {
      dag_deadline             = null
      dag_duration_seconds     = null
      days_of_week             = null
      deployment_id            = "cm1zkps2a0cv301ph39benet6"
      look_back_period_seconds = null
      task_duration_seconds    = null
    }
  }
  severity = "CRITICAL"
  type     = "DAG_FAILURE"
}
```
**DAG Success**
```
# __generated__ by Terraform from "cm4ntls0h01gg01mb195osvnt"
resource "astro_alert" "alert_cm4ntls0h01gg01mb195osvnt" {
  entity_id                = "cm1zkps2a0cv301ph39benet6"
  entity_type              = "DEPLOYMENT"
  name                     = "dag success"
  notification_channel_ids = ["cm3ey1sh2003b01mm3y0sebj8"]
  rules = {
    pattern_matches = [
      {
        entity_type   = "DAG_ID"
        operator_type = "IS"
        values        = ["success-dag-to-monitor"]
      },
    ]
    properties = {
      dag_deadline             = null
      dag_duration_seconds     = null
      days_of_week             = null
      deployment_id            = "cm1zkps2a0cv301ph39benet6"
      look_back_period_seconds = null
      task_duration_seconds    = null
    }
  }
  severity = "WARNING"
  type     = "DAG_SUCCESS"
}
```
**DAG Duration**
```
# __generated__ by Terraform from "cmcxzhr2c003401misr1vt9gv"
resource "astro_alert" "alert_cmcxzhr2c003401misr1vt9gv" {
  entity_id                = "cm1zkps2a0cv301ph39benet6"
  entity_type              = "DEPLOYMENT"
  name                     = "DAG Duration Alert"
  notification_channel_ids = ["cm4nwrvyg024h01mk2dn58m5s"]
  rules = {
    pattern_matches = [
      {
        entity_type   = "DAG_ID"
        operator_type = "EXCLUDES"
        values        = ["bad_dag"]
      },
      {
        entity_type   = "DAG_ID"
        operator_type = "IS"
        values        = ["*"]
      },
    ]
    properties = {
      dag_deadline             = null
      dag_duration_seconds     = 3600
      days_of_week             = null
      deployment_id            = "cm1zkps2a0cv301ph39benet6"
      look_back_period_seconds = null
      task_duration_seconds    = null
    }
  }
  severity = "CRITICAL"
  type     = "DAG_DURATION"
}
```
**DAG Timeliness**
```
# __generated__ by Terraform from "cmcxzjdox009r01kkxoycqwom"
resource "astro_alert" "alert_cmcxzjdox009r01kkxoycqwom" {
  entity_id                = "cm1zkps2a0cv301ph39benet6"
  entity_type              = "DEPLOYMENT"
  name                     = "DAG Timeliness Alert"
  notification_channel_ids = ["cm4nwrvyg024h01mk2dn58m5s"]
  rules = {
    pattern_matches = [
      {
        entity_type   = "DAG_ID"
        operator_type = "IS"
        values        = ["etl_dag"]
      },
    ]
    properties = {
      dag_deadline             = "08:00"
      dag_duration_seconds     = null
      days_of_week             = ["MONDAY"]
      deployment_id            = "cm1zkps2a0cv301ph39benet6"
      look_back_period_seconds = 3600
      task_duration_seconds    = null
    }
  }
  severity = "CRITICAL"
  type     = "DAG_TIMELINESS"
}
```
**Task Failure**
```
# __generated__ by Terraform from "cm4ntmjqc01iy01mk1q6wuq85"
resource "astro_alert" "alert_cm4ntmjqc01iy01mk1q6wuq85" {
  entity_id                = "cm1zkps2a0cv301ph39benet6"
  entity_type              = "DEPLOYMENT"
  name                     = "task failure alert"
  notification_channel_ids = ["cm3ey1sh2003b01mm3y0sebj8"]
  rules = {
    pattern_matches = [
      {
        entity_type   = "DAG_ID"
        operator_type = "IS"
        values        = ["failure-dag-to-monitor"]
      },
      {
        entity_type   = "TASK_ID"
        operator_type = "IS"
        values        = ["failure-task-to-monitor-3"]
      },
    ]
    properties = {
      dag_deadline             = null
      dag_duration_seconds     = null
      days_of_week             = null
      deployment_id            = "cm1zkps2a0cv301ph39benet6"
      look_back_period_seconds = null
      task_duration_seconds    = null
    }
  }
  severity = "WARNING"
  type     = "TASK_FAILURE"
}
```
**Task Duration**
```
# __generated__ by Terraform from "cmcxzjdof003a01mi2jf3e4fx"
resource "astro_alert" "alert_cmcxzjdof003a01mi2jf3e4fx" {
  entity_id                = "cm1zkps2a0cv301ph39benet6"
  entity_type              = "DEPLOYMENT"
  name                     = "Task Duration Alert"
  notification_channel_ids = ["cm4nwrvyg024h01mk2dn58m5s"]
  rules = {
    pattern_matches = [
      {
        entity_type   = "DAG_ID"
        operator_type = "INCLUDES"
        values        = ["etl_dag"]
      },
      {
        entity_type   = "TASK_ID"
        operator_type = "EXCLUDES"
        values        = ["bad_task"]
      },
    ]
    properties = {
      dag_deadline             = null
      dag_duration_seconds     = null
      days_of_week             = null
      deployment_id            = "cm1zkps2a0cv301ph39benet6"
      look_back_period_seconds = null
      task_duration_seconds    = 3600
    }
  }
  severity = "CRITICAL"
  type     = "TASK_DURATION"
}
```

### Notification Channel
**Email**
```
resource "astro_notification_channel" "notification_channel_cm4nwrvyg024h01mk2dn58m5s" {
	name = "org channel"
	type = "EMAIL"
	entity_id = "clx42kkcm01fo01o06agtmshg"
	entity_type = "ORGANIZATION"
	is_shared = true
	definition = {
		recipients = ["isaac.chung@astronomer.io"]
	}
}
```
**Slack**
```
resource "astro_notification_channel" "notification_channel_cmd55eji501h901l3c38w2mwg" {
	name = "Slack Notification Channel"
	type = "SLACK"
	entity_id = "clx42kkcm01fo01o06agtmshg"
	entity_type = "ORGANIZATION"
	is_shared = true
	definition = {
		webhook_url = "PLACEHOLDER_WEBHOOK_URL" # Replace with actual webhook URL
	}
}
```
**PagerDuty**
```
resource "astro_notification_channel" "notification_channel_cmd55epk501hb01l3fj3nufn2" {
	name = "PagerDuty Notification Channel"
	type = "PAGERDUTY"
	entity_id = "clx42sxw501gl01o0gjenthnh"
	entity_type = "WORKSPACE"
	is_shared = true
	definition = {
		integration_key = "PLACEHOLDER_INTEGRATION_KEY" # Replace with actual integration key
	}
}
```
**OpsGenie**
```
resource "astro_notification_channel" "notification_channel_cmd7s59ei1g2b01oi2n55tkoi" {
	name = "Example OpsGenie Notification Channel"
	type = "OPSGENIE"
	entity_id = "cm1zkps2a0cv301ph39benet6"
	entity_type = "DEPLOYMENT"
	is_shared = true
	definition = {
		api_key = "PLACEHOLDER_API_KEY" # Replace with actual API key
	}
}
```
**DAG Trigger**
```
resource "astro_notification_channel" "notification_channel_cmd55ftxf018t01mzy69ipeof" {
	name = "Dag trigger Notification Channel"
	type = "DAG_TRIGGER"
	entity_id = "clx42sxw501gl01o0gjenthnh"
	entity_type = "WORKSPACE"
	is_shared = true
	definition = {
		dag_id = "test_dag_will_trigger_alert_on_failure"
		deployment_api_token = "PLACEHOLDER_API_TOKEN" # Replace with actual deployment API token
		deployment_id = "cm1zkps2a0cv301ph39benet6"
	}
}
```

<img width="1944" height="296" alt="CleanShot 2025-07-22 at 11 47 38@2x" src="https://github.com/user-attachments/assets/b5d731f7-6a8b-4470-99c0-9aa1d8e73522" />


<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
