### PR TITLE
Fix import script missing remote execution support

### DIFF
--- a/import/import_script.go
+++ b/import/import_script.go
@@ -821,6 +821,7 @@ func generateDeploymentHCL(ctx context.Context, platformClient *platform.ClientW
 		contactEmailsString := formatContactEmails(deployment.ContactEmails)
 		environmentVariablesString := formatEnvironmentVariables(deployment.EnvironmentVariables)
 		workerQueuesString := formatWorkerQueues(deployment.WorkerQueues, (*string)(deployment.Executor))
+		remoteExecutionString := formatRemoteExecution(deployment.RemoteExecution)
 
 		deploymentType := deployment.Type
 
@@ -830,13 +831,37 @@ func generateDeploymentHCL(ctx context.Context, platformClient *platform.ClientW
 			workloadIdentityString = fmt.Sprintf(`desired_workload_identity = "%s"`, *workloadIdentity)
 		}
 
+		defaultTaskPodCpu := deployment.DefaultTaskPodCpu
+		defaultTaskPodCpuString := ""
+		if defaultTaskPodCpu != nil {
+			defaultTaskPodCpuString = fmt.Sprintf(`default_task_pod_cpu = "%s"`, *defaultTaskPodCpu)
+		}
+
+		defaultTaskPodMemory := deployment.DefaultTaskPodMemory
+		defaultTaskPodMemoryString := ""
+		if defaultTaskPodMemory != nil {
+			defaultTaskPodMemoryString = fmt.Sprintf(`default_task_pod_memory = "%s"`, *defaultTaskPodMemory)
+		}
+
+		resourceQuotaCpu := deployment.ResourceQuotaCpu
+		resourceQuotaCpuString := ""
+		if resourceQuotaCpu != nil {
+			resourceQuotaCpuString = fmt.Sprintf(`resource_quota_cpu = "%s"`, *resourceQuotaCpu)
+		}
+
+		resourceQuotaMemory := deployment.ResourceQuotaMemory
+		resourceQuotaMemoryString := ""
+		if resourceQuotaMemory != nil {
+			resourceQuotaMemoryString = fmt.Sprintf(`resource_quota_memory = "%s"`, *resourceQuotaMemory)
+		}
+
 		if *deploymentType == platform.DeploymentTypeDEDICATED {
 			deploymentHCL = fmt.Sprintf(`
 resource "astro_deployment" "deployment_%s" {
 	cluster_id = "%s"
 	%s
-	default_task_pod_cpu = "%s"
-	default_task_pod_memory = "%s"
+	%s
+	%s
 	description = "%s"
 	%s
 	executor = "%s"
@@ -845,20 +870,21 @@ resource "astro_deployment" "deployment_%s" {
 	is_development_mode = %t
 	is_high_availability = %t
 	name = "%s"
-	resource_quota_cpu = "%s"
-	resource_quota_memory = "%s"
+	%s
+	%s
 	scheduler_size = "%s"
 	type = "%s"
 	workspace_id = "%s"
 	%s
     %s
+	%s
 }
 `,
 				deployment.Id,
 				stringValue(deployment.ClusterId),
 				contactEmailsString,
-				stringValue(deployment.DefaultTaskPodCpu),
-				stringValue(deployment.DefaultTaskPodMemory),
+				defaultTaskPodCpuString,
+				defaultTaskPodMemoryString,
 				stringValue(deployment.Description),
 				environmentVariablesString,
 				stringValue((*string)(deployment.Executor)),
@@ -867,13 +893,14 @@ resource "astro_deployment" "deployment_%s" {
 				boolValue(deployment.IsDevelopmentMode),
 				boolValue(deployment.IsHighAvailability),
 				deployment.Name,
-				stringValue(deployment.ResourceQuotaCpu),
-				stringValue(deployment.ResourceQuotaMemory),
+				resourceQuotaCpuString,
+				resourceQuotaMemoryString,
 				stringValue((*string)(deployment.SchedulerSize)),
 				stringValue((*string)(deploymentType)),
 				deployment.WorkspaceId,
 				workerQueuesString,
 				workloadIdentityString,
+				remoteExecutionString,
 			)
 		} else if *deploymentType == platform.DeploymentTypeSTANDARD {
 			deploymentHCL = fmt.Sprintf(`
@@ -947,6 +974,17 @@ func boolValue(b *bool) bool {
 	return *b
 }
 
+func sliceValue(s []string) string {
+	if len(s) == 0 {
+		return "[]"
+	}
+	quotedSlice := make([]string, len(s))
+	for i, v := range s {
+		quotedSlice[i] = fmt.Sprintf(`"%s"`, v)
+	}
+	return fmt.Sprintf(`[%s]`, strings.Join(quotedSlice, ", "))
+}
+
 func formatContactEmails(emails *[]string) string {
 	if emails == nil || len(*emails) == 0 {
 		return fmt.Sprintf(`contact_emails = []`)
@@ -1005,5 +1043,34 @@ func formatWorkerQueues(queues *[]platform.WorkerQueue, executor *string) string
 	}
 
 	// If we've reached here, it means queues is nil or empty, and executor is not CELERY
+	return ""
+}
+
+func formatRemoteExecution(remoteExecution *platform.DeploymentRemoteExecution) string {
+	if remoteExecution == nil {
+		return ""
+	}
+
+	// If remote execution is enabled, format the string accordingly
+	if remoteExecution.Enabled {
+		taskLogBucket := remoteExecution.TaskLogBucket
+		taskLogBucketString := ""
+		if taskLogBucket != nil {
+			taskLogBucketString = fmt.Sprintf(`task_log_bucket = "%s"`, *taskLogBucket)
+		}
+		taskLogUrlPattern := remoteExecution.TaskLogUrlPattern
+		taskLogUrlPatternString := ""
+		if taskLogUrlPattern != nil {
+			taskLogUrlPatternString = fmt.Sprintf(`task_log_url_pattern = "%s"`, *taskLogUrlPattern)
+		}
+		return fmt.Sprintf(`remote_execution = {
+		enabled = true
+		allowed_ip_address_ranges = %s
+		%s
+		%s
+	}`, sliceValue(remoteExecution.AllowedIpAddressRanges), taskLogBucketString, taskLogUrlPatternString)
+	}
+
+	// If remote execution is not enabled, return an empty string
 	return ""
 }

--- a/internal/provider/schemas/remote_execution.go
+++ b/internal/provider/schemas/remote_execution.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -71,10 +72,22 @@ func RemoteExecutionResourceSchemaAttributes() map[string]resourceSchema.Attribu
 		"task_log_bucket": resourceSchema.StringAttribute{
 			MarkdownDescription: "The bucket for task logs",
 			Optional:            true,
+			Validators: []validator.String{
+				// An empty string is not allowed,
+				// as the API removes it from the response if set to an empty string,
+				// which causes issues with the provider.
+				stringvalidator.LengthAtLeast(1),
+			},
 		},
 		"task_log_url_pattern": resourceSchema.StringAttribute{
 			MarkdownDescription: "The URL pattern for task logs",
 			Optional:            true,
+			Validators: []validator.String{
+				// An empty string is not allowed,
+				// as the API removes it from the response if set to an empty string,
+				// which causes issues with the provider.
+				stringvalidator.LengthAtLeast(1),
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Description

<!--- Describe the purpose of this pull request. --->

Currently, the import script does not add the `remote_execution` config to generated deployments (if they are remote).

## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

1. Created a Remote Deployment (id: `cmdftmodx00fz01l6ffh6p5fk`)
2. Ran the import script locally to validate that the `remote_execution` exists on the imported deployment
```
Terraform Import Script Starting
Resources to import:  [deployment]
Using organization ID: clx42kkcm01fo01o06agtmshg
Terraform version 1.12.2 is installed and meets the minimum required version.
Importing deployments for organization clx42kkcm01fo01o06agtmshg
Importing Deployments: [cmdftmodx00fz01l6ffh6p5fk cm1zkps2a0cv301ph39benet6 cm070pg0r00wd01qgnskk0dir]
Successfully handled resource deployment
Successfully wrote import configuration to import.tf
Running terraform init
Initializing the backend...
Initializing provider plugins...
- Finding latest version of astronomer/astro...
- Installing astronomer/astro v1.0.7...
- Installed astronomer/astro v1.0.7 (signed by a HashiCorp partner, key ID F5206453FDEA33CF)
Partner and community providers are signed by their developers.
If you'd like to know more about provider signing, you can read about it here:
https://developer.hashicorp.com/terraform/cli/plugins/signing
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - astronomer/astro in /Users/felix.uellendall/Projects/terraform-provider-astro
│ 
│ Skip terraform init when using provider development overrides. It is not necessary and may error unexpectedly.
╵
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
generated.tf does not exist, no need to delete
terraform.tfstate does not exist, no need to delete
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - astronomer/astro in /Users/felix.uellendall/Projects/terraform-provider-astro
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
generated.tf does not exist. Creating new file with deployment information.
Generated import for astro_deployment.deployment_cmdftmodx00fz01l6ffh6p5fk
Generated import for astro_deployment.deployment_cm1zkps2a0cv301ph39benet6
Generated import for astro_deployment.deployment_cm070pg0r00wd01qgnskk0dir
Successfully updated generated.tf with deployment information.
Import process completed successfully. The 'generated.tf' file now includes all resources, including deployments.
Import process completed. Summary:
Resource deployment processed successfully
```
3. Ran `terraform apply`
```
Plan: 3 to import, 0 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

astro_deployment.deployment_cmdftmodx00fz01l6ffh6p5fk: Importing... [id=cmdftmodx00fz01l6ffh6p5fk]
astro_deployment.deployment_cmdftmodx00fz01l6ffh6p5fk: Import complete [id=cmdftmodx00fz01l6ffh6p5fk]
astro_deployment.deployment_cm070pg0r00wd01qgnskk0dir: Importing... [id=cm070pg0r00wd01qgnskk0dir]
astro_deployment.deployment_cm070pg0r00wd01qgnskk0dir: Import complete [id=cm070pg0r00wd01qgnskk0dir]
astro_deployment.deployment_cm1zkps2a0cv301ph39benet6: Importing... [id=cm1zkps2a0cv301ph39benet6]
astro_deployment.deployment_cm1zkps2a0cv301ph39benet6: Import complete [id=cm1zkps2a0cv301ph39benet6]

Apply complete! Resources: 3 imported, 0 added, 0 changed, 0 destroyed.
```

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
