### PR TITLE
[BUG]: Fix Team Resource to allow empty list of member ids

### DIFF
--- a/internal/provider/models/team.go
+++ b/internal/provider/models/team.go
@@ -90,7 +90,7 @@ func (data *TeamResource) ReadFromResponse(ctx context.Context, team *iam.Team, 
 	} else {
 		data.Description = types.StringNull()
 	}
-	if memberIds != nil && len(*memberIds) > 0 {
+	if memberIds != nil {
 		data.MemberIds, diags = utils.StringSet(memberIds)
 		if diags.HasError() {
 			return diags

--- a/internal/provider/resources/resource_team.go
+++ b/internal/provider/resources/resource_team.go
@@ -160,17 +160,21 @@ func (r *TeamResource) Create(
 		return
 	}
 
-	memberIds, diags := utils.TypesSetToStringSlice(ctx, data.MemberIds)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
+	var memberIdsPtr *[]string
+	if !data.MemberIds.IsNull() {
+		memberIds, diags := utils.TypesSetToStringSlice(ctx, data.MemberIds)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		memberIdsPtr = &memberIds
 	}
 
 	// Create the team request
 	createTeamRequest := iam.CreateTeamRequest{
 		Name:             data.Name.ValueString(),
 		Description:      data.Description.ValueStringPointer(),
-		MemberIds:        &memberIds,
+		MemberIds:        memberIdsPtr,
 		OrganizationRole: lo.ToPtr(iam.CreateTeamRequestOrganizationRole(data.OrganizationRole.ValueString())),
 	}
 
@@ -242,7 +246,7 @@ func (r *TeamResource) Create(
 		return
 	}
 
-	diags = data.ReadFromResponse(ctx, teamResp.JSON200, &memberIds)
+	diags = data.ReadFromResponse(ctx, teamResp.JSON200, memberIdsPtr)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -295,13 +299,17 @@ func (r *TeamResource) Read(
 		return
 	}
 
-	memberIds, diags := utils.TypesSetToStringSlice(ctx, data.MemberIds)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
+	var memberIdsPtr *[]string
+	if !data.MemberIds.IsNull() {
+		memberIds, diags := utils.TypesSetToStringSlice(ctx, data.MemberIds)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		memberIdsPtr = &memberIds
 	}
 
-	diags = data.ReadFromResponse(ctx, team.JSON200, &memberIds)
+	diags := data.ReadFromResponse(ctx, team.JSON200, memberIdsPtr)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -336,10 +344,14 @@ func (r *TeamResource) Update(
 	}
 
 	// Update team members
-	newMemberIds, diags := r.UpdateTeamMembers(ctx, data)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
+	var newMemberIdsPtr *[]string
+	if !data.MemberIds.IsNull() {
+		newMemberIds, diags := r.UpdateTeamMembers(ctx, data)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		newMemberIdsPtr = &newMemberIds
 	}
 
 	// Update team
@@ -398,7 +410,7 @@ func (r *TeamResource) Update(
 		return
 	}
 
-	diags = data.ReadFromResponse(ctx, teamResp.JSON200, &newMemberIds)
+	diags = data.ReadFromResponse(ctx, teamResp.JSON200, newMemberIdsPtr)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/resources/resource_team.go
+++ b/internal/provider/resources/resource_team.go
@@ -14,10 +14,12 @@ import (
 	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
 	"github.com/astronomer/terraform-provider-astro/internal/provider/schemas"
 	"github.com/astronomer/terraform-provider-astro/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/samber/lo"
 )
@@ -352,6 +354,16 @@ func (r *TeamResource) Update(
 			return
 		}
 		newMemberIdsPtr = &newMemberIds
+	} else {
+		originalMemberIds := data.MemberIds
+		data.MemberIds = types.SetValueMust(types.StringType, []attr.Value{})
+		_, diags := r.UpdateTeamMembers(ctx, data)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		data.MemberIds = originalMemberIds
+		newMemberIdsPtr = nil
 	}
 
 	// Update team

--- a/internal/provider/resources/resource_team_test.go
+++ b/internal/provider/resources/resource_team_test.go
@@ -36,6 +36,7 @@ func TestAcc_ResourceTeam(t *testing.T) {
 		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckTeamExistence(t, teamName, false),
+			testAccCheckTeamExistence(t, teamName+"_empty", false),
 		),
 		Steps: []resource.TestStep{
 			// Test failure: disable team resource if org is isScimEnabled
@@ -133,6 +134,21 @@ func TestAcc_ResourceTeam(t *testing.T) {
 					},
 				}),
 				ExpectError: regexp.MustCompile("Unable to mutate roles, not every deployment role has a corresponding valid deployment"),
+			},
+			// Create team with empty member_ids array
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + team(teamInput{
+					Name:             teamName + "_empty",
+					Description:      utils.TestResourceDescription,
+					MemberIds:        []string{},
+					OrganizationRole: string(iam.ORGANIZATIONOWNER),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("astro_team.%v_empty", teamName), "id"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("astro_team.%v_empty", teamName), "name", teamName+"_empty"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("astro_team.%v_empty", teamName), "member_ids.#", "0"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("astro_team.%v_empty", teamName), "organization_role", string(iam.ORGANIZATIONOWNER)),
+				),
 			},
 			// Create team with all fields
 			{

--- a/internal/provider/resources/resource_team_test.go
+++ b/internal/provider/resources/resource_team_test.go
@@ -257,7 +257,7 @@ type teamInput struct {
 	Name             string
 	Description      string
 	MemberIds        []string
-	IncludeMemberIds bool // whether to include member_ids in the config
+	IncludeMemberIds bool
 	OrganizationRole string
 	DeploymentRoles  []utils.Role
 	WorkspaceRoles   []utils.Role


### PR DESCRIPTION
## Description
This PR fixes logic in Team Resource to allow an empty list of member ids.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
#217 

## 🧪 Functional Testing
- Added acceptance test for empty member ids list

Manual Terraform Tests:
Creating a new team
```
resource "astro_team" "example_team" {
  name = "Example Team"
  organization_role = "ORGANIZATION_OWNER"
  member_ids = []
}
```
<img width="1044" height="740" alt="CleanShot 2025-07-31 at 14 57 59@2x" src="https://github.com/user-attachments/assets/5c0e6954-f4f7-4575-8070-193051b9fe39" />

Updating team

From:
```
resource "astro_team" "example_team" {
  name = "Example Team"
  organization_role = "ORGANIZATION_OWNER"
  member_ids = ["id"]
}
```
<img width="1356" height="1040" alt="CleanShot 2025-07-31 at 17 26 41@2x" src="https://github.com/user-attachments/assets/65da6e56-b8a6-4297-a9b4-cbda73dd5dac" />

To:
```
resource "astro_team" "example_team" {
  name = "Example Team"
  organization_role = "ORGANIZATION_OWNER"
}
```
<img width="1358" height="992" alt="CleanShot 2025-07-31 at 17 24 42@2x" src="https://github.com/user-attachments/assets/5ebe70ab-0cec-40f1-9d87-2d62b204bcfd" />


<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
