### PR TITLE
escape deployment env var json string values

### DIFF
--- a/import/import_script.go
+++ b/import/import_script.go
@@ -1327,7 +1327,7 @@ func formatEnvironmentVariables(envVars *[]platform.DeploymentEnvironmentVariabl
 		return fmt.Sprintf(`environment_variables = []`)
 	}
 	variables := lo.Map(*envVars, func(envVar platform.DeploymentEnvironmentVariable, _ int) string {
-		value := fmt.Sprintf(`"%s"`, stringValue(envVar.Value))
+		value := fmt.Sprintf(`"%s"`, strings.ReplaceAll(*envVar.Value, `"`, `\"`))
 
 		if envVar.IsSecret {
 			value = "null"


### PR DESCRIPTION
## Description

<!--- Describe the purpose of this pull request. --->

Fixes an issue in which imported deployments with double quotes in their values were not properly parsed.

## 🎟 Issue(s)

## 🧪 Functional Testing



Verified it imported successfully with the escapes and that changes to the value containing the escaped quotes could be applied to the deployments.

## 📸 Screenshots
imported file with escapes:
<img width="604" height="178" alt="Screenshot 2025-08-12 at 4 27 18 PM" src="https://github.com/user-attachments/assets/40e8ac02-7aa0-4f67-9f09-c2818382c515" />
astro ui before apply:
<img width="657" height="264" alt="Screenshot 2025-08-12 at 4 19 29 PM" src="https://github.com/user-attachments/assets/c437832b-4e25-4a6b-831f-15bad0886223" />
astro ui after apply:
<img width="599" height="204" alt="Screenshot 2025-08-12 at 4 19 55 PM" src="https://github.com/user-attachments/assets/9cc3aaff-25ce-41c2-8788-88b225d60d4d" />




## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
