### PR TITLE
Fix Bug with Mutating Notification Channels with Terraform Variables

### DIFF
--- a/internal/provider/validators/notification_channel.go
+++ b/internal/provider/validators/notification_channel.go
@@ -139,7 +139,7 @@ func (v notificationChannelDefinitionValidator) ValidateObject(ctx context.Conte
 	required := requiredFields[channelTypeStr]
 	var missingFields []string
 	for _, requiredField := range required {
-		if fieldValue, exists := definitionAttrs[requiredField]; !exists || fieldValue.IsNull() || fieldValue.IsUnknown() {
+		if fieldValue, exists := definitionAttrs[requiredField]; !exists || fieldValue.IsNull() {
 			missingFields = append(missingFields, requiredField)
 		}
 	}


### PR DESCRIPTION
## Description

This PR allows users to mutate notification channels with terraform variables.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
#245 
## 🧪 Functional Testing
```
variable "slack_webhook_url" {
  description = "The webhook URL for the Slack notification channel"
  type = string
  default = "https://hooks.slack.com/services/XXXXX"
}

resource "astro_notification_channel" "slack_notification_channel" {
  name        = "Slack Notification Channel"
  type        = "SLACK"
  entity_type = "DEPLOYMENT"
  entity_id   = "cm1zkps2a0cv301ph39benet6"
  definition = {
    webhook_url = slack_webhook_url
  }
  is_shared = true
}
```
<img width="1612" height="138" alt="CleanShot 2025-09-09 at 11 54 18@2x" src="https://github.com/user-attachments/assets/149b17c7-3b95-4d12-af4f-569b036f33b6" />


<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
