### PR TITLE
reuse token from state when updating an api token

### DIFF
--- a/internal/provider/resources/resource_api_token.go
+++ b/internal/provider/resources/resource_api_token.go
@@ -440,7 +440,7 @@ func (r *ApiTokenResource) Update(
 	}
 
 	tflog.Trace(ctx, fmt.Sprintf("updated an API token resource: %v", data.Id.ValueString()))
-
+	data.Token = currentState.Token // use current states token as it is not returned in request due to sensitive nature
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/resources/resource_api_token_test.go
+++ b/internal/provider/resources/resource_api_token_test.go
@@ -196,6 +196,7 @@ func TestAcc_ResourceOrganizationApiToken(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceVar, "roles.2.entity_id", deploymentId),
 					resource.TestCheckResourceAttr(resourceVar, "roles.2.entity_type", string(iam.DEPLOYMENT)),
 					resource.TestCheckResourceAttr(resourceVar, "roles.2.role", "DEPLOYMENT_ADMIN"),
+					resource.TestCheckResourceAttrSet(resourceVar, "token"),
 					// Check via API that api token exists
 					testAccCheckApiTokenExistence(t, checkApiTokensExistenceInput{name: apiTokenName, organization: true, shouldExist: true}),
 				),
@@ -229,6 +230,7 @@ func TestAcc_ResourceOrganizationApiToken(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceVar, "description", "new description"),
 					// Check via API that api token exists
 					testAccCheckApiTokenExistence(t, checkApiTokensExistenceInput{name: apiTokenName, organization: true, shouldExist: true}),
+					resource.TestCheckResourceAttrSet(resourceVar, "token"),
 				),
 			},
 			// Test invalid expiry period update


### PR DESCRIPTION
## Description

Fixes an issue in which an updated api token was losing the token value in the terraform state

## 🎟 Issue(s)

## 🧪 Functional Testing

Tested the update locally

## 📸 Screenshots

Before Change (note token is null after update):
<img width="1231" height="542" alt="Screenshot 2025-09-30 at 8 40 06 AM" src="https://github.com/user-attachments/assets/b735d023-cae3-4d9a-9005-eac2837d1fa0" />

After Change (note token is not null after update):
<img width="740" height="337" alt="Screenshot 2025-09-30 at 8 42 04 AM" src="https://github.com/user-attachments/assets/13c29a00-fcbc-436f-9479-7f0dc3236ce7" />


## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
