### PR TITLE
Add env secret support to workflows for external PRs

### DIFF
--- a/.github/workflows/import-script-tests.yml
+++ b/.github/workflows/import-script-tests.yml
@@ -39,6 +39,7 @@ jobs:
     name: Import Script Tests
     needs: build
     timeout-minutes: 20
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'acc-secrets' || null }} # Only sets env if pull request is from a different repository
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -45,6 +45,7 @@ jobs:
     name: Terraform Provider Acceptance Tests
     needs: build
     timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'acc-secrets' || null }} # Only sets env if pull request is from a different repository
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## Description

Currently external users are unable to run GitHub Action workflows with repo secrets from forked PRs due to a security restriction. This PR adds environment secret support for external PRs such that when an external PR is approved, users will be able to run workflows that rely on env secrets. The main change is in the workflow yaml file.

As part of this change, I also created a new environment and added all the required environment secrets. 
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)

#256 
## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
