### PR TITLE
test: modify import script test to support external pr jobs

### DIFF
--- a/.github/workflows/import-script-tests.yml
+++ b/.github/workflows/import-script-tests.yml
@@ -1,7 +1,8 @@
 name: Import Script Tests
 
 on:
-  pull_request:
+  pull_request_target:  # For external PRs (runs in base repo context)
+  pull_request:         # For internal PRs (keep for faster feedback)
   push:
     branches:
       - main
@@ -38,8 +39,12 @@ jobs:
   test-import-script:
     name: Import Script Tests
     needs: build
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     timeout-minutes: 20
-    environment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner && 'acc-secrets' || null }}
+    environment: ${{ github.event_name == 'pull_request_target' && 'acc-secrets' || null }}
     strategy:
       fail-fast: true
       matrix:
@@ -48,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: 'go.mod'


### PR DESCRIPTION
## Description

Currently, the import script test job is failing on external PRs as it cannot get the secret envs it needs to run. This PR modifies the import script test GHA so that it can reach the acc-test env and run properly.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
#272 
## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
