### PR TITLE
fix: astro deployment worker queues bug

### DIFF
--- a/internal/provider/resources/resource_deployment.go
+++ b/internal/provider/resources/resource_deployment.go
@@ -985,6 +985,11 @@ func validateHostedConfig(ctx context.Context, data *models.DeploymentResource) 
 
 	// For ASTRO executor without Remote Execution, require at least one worker_queue named 'default'
 	if data.Executor.ValueString() == string(platform.DeploymentExecutorASTRO) && data.RemoteExecution.IsNull() {
+		// Skip validation if worker_queues is unknown (e.g., provided via a local or variable).
+		// The actual value will be validated at plan/apply time when it's resolved.
+		if data.WorkerQueues.IsUnknown() {
+			return diags
+		}
 		if len(data.WorkerQueues.Elements()) == 0 {
 			diags.AddError(
 				"worker_queues is required for 'ASTRO' executor",


### PR DESCRIPTION
## Description

This PR fixes a bug with creating deployments using the Astro executor where worker queues defined in locals or variables are not recognized during `terraform plan` or `terraform apply`.
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
#247 
## 🧪 Functional Testing
- Acceptance tests
- Manual tests:

Input:
```
variable "environment" {
  type    = string
  default = "dev"
}

locals {
  worker_queues_options = {
    "prod" = [
      {
        name               = "default"
        is_default         = true
        astro_machine      = "A10"
        max_worker_count   = 10
        min_worker_count   = 0
        worker_concurrency = 5
      }
    ]
    "default" = [
      {
        name               = "default"
        is_default         = true
        astro_machine      = "A5"
        max_worker_count   = 5
        min_worker_count   = 0
        worker_concurrency = 1
      }
    ]
  }
  worker_queues = lookup(local.worker_queues_options, var.environment, local.worker_queues_options.default)
}

resource "astro_deployment" "test_astro_with_local" {
  original_astro_runtime_version = "3.0-1"
  name                           = "test-astro-local-worker-queues"
  description                    = "Test deployment"
  type                           = "STANDARD"
  cloud_provider                 = "AWS"
  region                         = "us-east-1"
  contact_emails                 = []
  default_task_pod_cpu           = "0.25"
  default_task_pod_memory        = "0.5Gi"
  resource_quota_cpu             = "10"
  resource_quota_memory          = "20Gi"
  executor             = "ASTRO"
  scheduler_size       = "SMALL"
  is_cicd_enforced     = false
  is_dag_deploy_enabled = false
  is_development_mode  = false
  is_high_availability = false
  workspace_id         = "clx42sxw501gl01o0gjenthnh"
  worker_queues = local.worker_queues
  environment_variables = []
}
```

Response:
```
  # astro_deployment.test_astro_with_local will be created
  + resource "astro_deployment" "test_astro_with_local" {
      + airflow_version                = (known after apply)
      + astro_runtime_version          = (known after apply)
      + cloud_provider                 = "AWS"
      + cluster_id                     = (known after apply)
      + contact_emails                 = []
      + created_at                     = (known after apply)
      + created_by                     = (known after apply)
      + dag_tarball_version            = (known after apply)
      + default_task_pod_cpu           = "0.25"
      + default_task_pod_memory        = "0.5Gi"
      + description                    = "Test deployment for issue #247 - ASTRO executor with worker_queues from local"
      + desired_dag_tarball_version    = (known after apply)
      + environment_variables          = []
      + executor                       = "ASTRO"
      + external_ips                   = (known after apply)
      + id                             = (known after apply)
      + image_repository               = (known after apply)
      + image_tag                      = (known after apply)
      + image_version                  = (known after apply)
      + is_cicd_enforced               = false
      + is_dag_deploy_enabled          = false
      + is_development_mode            = false
      + is_high_availability           = false
      + name                           = "test-astro-local-worker-queues"
      + namespace                      = (known after apply)
      + oidc_issuer_url                = (known after apply)
      + original_astro_runtime_version = "3.0-1"
      + region                         = "us-east-1"
      + resource_quota_cpu             = "10"
      + resource_quota_memory          = "20Gi"
      + scaling_status                 = (known after apply)
      + scheduler_cpu                  = (known after apply)
      + scheduler_memory               = (known after apply)
      + scheduler_replicas             = (known after apply)
      + scheduler_size                 = "SMALL"
      + status                         = (known after apply)
      + status_reason                  = (known after apply)
      + type                           = "STANDARD"
      + updated_at                     = (known after apply)
      + updated_by                     = (known after apply)
      + webserver_airflow_api_url      = (known after apply)
      + webserver_ingress_hostname     = (known after apply)
      + webserver_url                  = (known after apply)
      + worker_queues                  = [
          + {
              + astro_machine      = "A5"
              + is_default         = true
              + max_worker_count   = 5
              + min_worker_count   = 0
              + name               = "default"
              + pod_cpu            = (known after apply)
              + pod_memory         = (known after apply)
              + worker_concurrency = 1
            },
        ]
      + workload_identity              = (known after apply)
      + workspace_id                   = "clx42sxw501gl01o0gjenthnh"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + astro_deployment_id  = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

astro_deployment.test_astro_with_local: Creating...
astro_deployment.test_astro_with_local: Creation complete after 2s [id=cmknr7sal033k01i84f0rwk40]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

astro_deployment_id = "cmknr7sal033k01i84f0rwk40"
```
<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
