### PR TITLE
Temporarily disable flaky cluster acceptance test

### DIFF
--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -122,42 +122,42 @@ func TestAcc_ResourceClusterAwsWithDedicatedDeployments(t *testing.T) {
 				),
 			},
 			// Just update cluster and remove workspace restrictions
-			// {
-			// 	Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
-			// 		workspace(workspaceName, workspaceName, utils.TestResourceDescription, false) +
-			// 		cluster(clusterInput{
-			// 			Name:          awsClusterName,
-			// 			Region:        "us-east-1",
-			// 			CloudProvider: "AWS",
-			// 		}) +
-			// 		dedicatedDeployment(dedicatedDeploymentInput{
-			// 			ClusterId:     awsResourceVarId,
-			// 			WorkspaceId:   workspaceResourceVarId,
-			// 			Name:          awsDeploymentName,
-			// 			Description:   "deployment description",
-			// 			SchedulerSize: "SMALL",
-			// 		}),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		// Check cluster
-			// 		resource.TestCheckResourceAttr(awsResourceVar, "name", awsClusterName),
-			// 		resource.TestCheckResourceAttr(awsResourceVar, "region", "us-east-1"),
-			// 		resource.TestCheckResourceAttr(awsResourceVar, "cloud_provider", "AWS"),
-			// 		resource.TestCheckResourceAttrSet(awsResourceVar, "vpc_subnet_range"),
-			// 		resource.TestCheckResourceAttr(awsResourceVar, "workspace_ids.#", "0"),
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					workspace(workspaceName, workspaceName, utils.TestResourceDescription, false) +
+					cluster(clusterInput{
+						Name:          awsClusterName,
+						Region:        "us-east-1",
+						CloudProvider: "AWS",
+					}) +
+					dedicatedDeployment(dedicatedDeploymentInput{
+						ClusterId:     awsResourceVarId,
+						WorkspaceId:   workspaceResourceVarId,
+						Name:          awsDeploymentName,
+						Description:   "deployment description",
+						SchedulerSize: "SMALL",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					// Check cluster
+					resource.TestCheckResourceAttr(awsResourceVar, "name", awsClusterName),
+					resource.TestCheckResourceAttr(awsResourceVar, "region", "us-east-1"),
+					resource.TestCheckResourceAttr(awsResourceVar, "cloud_provider", "AWS"),
+					resource.TestCheckResourceAttrSet(awsResourceVar, "vpc_subnet_range"),
+					resource.TestCheckResourceAttr(awsResourceVar, "workspace_ids.#", "0"),
 
-			// 		// Check via API that cluster exists
-			// 		testAccCheckClusterExistence(t, awsClusterName, true, true),
+					// Check via API that cluster exists
+					testAccCheckClusterExistence(t, awsClusterName, true, true),
 
-			// 		// Check dedicated deployment
-			// 		resource.TestCheckResourceAttr(awsDeploymentResourceVar, "name", awsDeploymentName),
-			// 		resource.TestCheckResourceAttr(awsDeploymentResourceVar, "description", "deployment description"),
-			// 		resource.TestCheckResourceAttr(awsDeploymentResourceVar, "type", "DEDICATED"),
-			// 		resource.TestCheckResourceAttr(awsDeploymentResourceVar, "scheduler_size", "SMALL"),
+					// Check dedicated deployment
+					resource.TestCheckResourceAttr(awsDeploymentResourceVar, "name", awsDeploymentName),
+					resource.TestCheckResourceAttr(awsDeploymentResourceVar, "description", "deployment description"),
+					resource.TestCheckResourceAttr(awsDeploymentResourceVar, "type", "DEDICATED"),
+					resource.TestCheckResourceAttr(awsDeploymentResourceVar, "scheduler_size", "SMALL"),
 
-			// 		// Check via API that deployment exists
-			// 		testAccCheckDeploymentExistence(t, awsDeploymentName, true, true),
-			// 	),
-			// },
+					// Check via API that deployment exists
+					testAccCheckDeploymentExistence(t, awsDeploymentName, true, true),
+				),
+			},
 			// Change properties of cluster and deployment and check they have been updated in terraform state
 			// Add back workspace restrictions
 			// {


### PR DESCRIPTION
## Description

This PR temporarily disables a broken cluster acceptance test. This specific step in the test tests update cluster (which is already covered in the step above it).
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)
https://linear.app/astronomer/issue/CPP-237/temporarily-disable-broken-cluster-acceptance-tests
## 🧪 Functional Testing
- Acceptance tests pass
<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
