### PR TITLE
include organization observe roles

### DIFF
--- a/internal/provider/common/role.go
+++ b/internal/provider/common/role.go
@@ -89,7 +89,13 @@ func ValidateRoleMatchesEntityType(role string, scopeType string) bool {
 		return false
 	}
 
-	organizationRoles := []string{string(iam.UserOrganizationRoleORGANIZATIONBILLINGADMIN), string(iam.UserOrganizationRoleORGANIZATIONMEMBER), string(iam.UserOrganizationRoleORGANIZATIONOWNER)}
+	organizationRoles := []string{
+		string(iam.UserOrganizationRoleORGANIZATIONBILLINGADMIN),
+		string(iam.UserOrganizationRoleORGANIZATIONMEMBER),
+		string(iam.UserOrganizationRoleORGANIZATIONOWNER),
+		string(iam.UserOrganizationRoleORGANIZATIONOBSERVEADMIN),
+		string(iam.UserOrganizationRoleORGANIZATIONOBSERVEMEMBER),
+	}
 	workspaceRoles := []string{string(iam.WORKSPACEACCESSOR), string(iam.WORKSPACEAUTHOR), string(iam.WORKSPACEMEMBER), string(iam.WORKSPACEOWNER), string(iam.WORKSPACEOPERATOR)}
 	deploymentRoles := []string{"DEPLOYMENT_ADMIN"}
 	var nonEntityRoles []string

--- a/internal/provider/common/role_test.go
+++ b/internal/provider/common/role_test.go
@@ -1,0 +1,130 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
+	"github.com/astronomer/terraform-provider-astro/internal/provider/common"
+)
+
+func TestValidateRoleMatchesEntityType(t *testing.T) {
+	tests := []struct {
+		name      string
+		role      string
+		scopeType string
+		want      bool
+	}{
+		{
+			name:      "empty role",
+			role:      "",
+			scopeType: "organization",
+			want:      false,
+		},
+		{
+			name:      "empty scope type",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOWNER),
+			scopeType: "",
+			want:      false,
+		},
+		{
+			name:      "organization owner for organization scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOWNER),
+			scopeType: "organization",
+			want:      true,
+		},
+		{
+			name:      "organization member for organization scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONMEMBER),
+			scopeType: "organization",
+			want:      true,
+		},
+		{
+			name:      "organization billing admin for organization scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONBILLINGADMIN),
+			scopeType: "organization",
+			want:      true,
+		},
+		{
+			name:      "organization observe admin for organization scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOBSERVEADMIN),
+			scopeType: "organization",
+			want:      true,
+		},
+		{
+			name:      "organization observe member for organization scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOBSERVEMEMBER),
+			scopeType: "organization",
+			want:      true,
+		},
+		{
+			name:      "workspace role invalid for organization scope",
+			role:      string(iam.WORKSPACEOWNER),
+			scopeType: "organization",
+			want:      false,
+		},
+		{
+			name:      "deployment role invalid for organization scope",
+			role:      "DEPLOYMENT_ADMIN",
+			scopeType: "organization",
+			want:      false,
+		},
+		{
+			name:      "observe member invalid for workspace scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOBSERVEMEMBER),
+			scopeType: "workspace",
+			want:      false,
+		},
+		{
+			name:      "observe admin invalid for workspace scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOBSERVEADMIN),
+			scopeType: "workspace",
+			want:      false,
+		},
+		{
+			name:      "organization owner invalid for workspace scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOWNER),
+			scopeType: "workspace",
+			want:      false,
+		},
+		{
+			name:      "workspace owner valid for workspace scope",
+			role:      string(iam.WORKSPACEOWNER),
+			scopeType: "workspace",
+			want:      true,
+		},
+		{
+			name:      "observe member invalid for deployment scope",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOBSERVEMEMBER),
+			scopeType: "deployment",
+			want:      false,
+		},
+		{
+			name:      "deployment admin valid for deployment scope",
+			role:      "DEPLOYMENT_ADMIN",
+			scopeType: "deployment",
+			want:      true,
+		},
+		{
+			name:      "scope type is case insensitive",
+			role:      string(iam.UserOrganizationRoleORGANIZATIONOBSERVEMEMBER),
+			scopeType: "ORGANIZATION",
+			want:      true,
+		},
+		{
+			name:      "unlisted role not treated as workspace or deployment role for organization scope",
+			role:      "ORGANIZATION_UNKNOWN",
+			scopeType: "organization",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := common.ValidateRoleMatchesEntityType(tt.role, tt.scopeType)
+			if got != tt.want {
+				t.Fatalf("ValidateRoleMatchesEntityType(%q, %q) = %v, want %v",
+					tt.role, tt.scopeType, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/resources/resource_user_roles_test.go
+++ b/internal/provider/resources/resource_user_roles_test.go
@@ -28,6 +28,16 @@ func TestAcc_ResourceUserRoles(t *testing.T) {
 		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					userRoles(userRolesInput{OrganizationRole: ""}),
+				ExpectError: regexp.MustCompile("Attribute organization_role value must be one of"),
+			},
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					userRoles(userRolesInput{OrganizationRole: "ORGANIZATION_NOT_A_ROLE"}),
+				ExpectError: regexp.MustCompile("Attribute organization_role value must be one of"),
+			},
 			// Test failure: check for mismatch in role and entity type
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +

--- a/internal/provider/schemas/team.go
+++ b/internal/provider/schemas/team.go
@@ -126,6 +126,8 @@ func TeamResourceSchemaAttributes() map[string]resourceSchema.Attribute {
 				stringvalidator.OneOf(string(iam.TeamOrganizationRoleORGANIZATIONOWNER),
 					string(iam.TeamOrganizationRoleORGANIZATIONMEMBER),
 					string(iam.TeamOrganizationRoleORGANIZATIONBILLINGADMIN),
+					string(iam.TeamOrganizationRoleORGANIZATIONOBSERVEADMIN),
+					string(iam.TeamOrganizationRoleORGANIZATIONOBSERVEMEMBER),
 				),
 			},
 		},

--- a/internal/provider/schemas/team_roles.go
+++ b/internal/provider/schemas/team_roles.go
@@ -26,6 +26,8 @@ func ResourceTeamRolesSchemaAttributes() map[string]resourceSchema.Attribute {
 					string(iam.TeamOrganizationRoleORGANIZATIONOWNER),
 					string(iam.TeamOrganizationRoleORGANIZATIONMEMBER),
 					string(iam.TeamOrganizationRoleORGANIZATIONBILLINGADMIN),
+					string(iam.TeamOrganizationRoleORGANIZATIONOBSERVEADMIN),
+					string(iam.TeamOrganizationRoleORGANIZATIONOBSERVEMEMBER),
 				),
 			},
 		},

--- a/internal/provider/schemas/user_roles.go
+++ b/internal/provider/schemas/user_roles.go
@@ -26,6 +26,8 @@ func ResourceUserRolesSchemaAttributes() map[string]resourceSchema.Attribute {
 					string(iam.UserOrganizationRoleORGANIZATIONOWNER),
 					string(iam.UserOrganizationRoleORGANIZATIONMEMBER),
 					string(iam.UserOrganizationRoleORGANIZATIONBILLINGADMIN),
+					string(iam.UserOrganizationRoleORGANIZATIONOBSERVEADMIN),
+					string(iam.UserOrganizationRoleORGANIZATIONOBSERVEMEMBER),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

Terraform rejected valid organization roles `ORGANIZATION_OBSERVE_ADMIN` and `ORGANIZATION_OBSERVE_MEMBER` because `organization_role` used a `stringvalidator.OneOf` list that only included owner, member, and billing admin. The IAM client and API already define all five roles; this was provider-side schema validation only.

This change extends those validators on `astro_user_roles`, `astro_team_roles`, and `astro_team`, and adds the observe roles to `organizationRoles` in `ValidateRoleMatchesEntityType` so API token role checks treat them like other organization roles 



## 🎟 Issue(s)

- Closes https://github.com/astronomer/terraform-provider-astro/issues/283

## 🧪 Functional Testing

1. **Plan-time validation:** Run `terraform validate` (or `terraform plan`) with `organization_role = "ORGANIZATION_OBSERVE_MEMBER"` (and optionally `ORGANIZATION_OBSERVE_ADMIN`) on `astro_user_roles`, `astro_team_roles`, and `astro_team`; confirm there is no “value must be one of” error for those values.
2. **Apply (org that supports Observe roles):** Apply a minimal config that sets a user or team to `ORGANIZATION_OBSERVE_MEMBER` and confirm the IAM API returns the same role after apply.
3. **Regression — API tokens:** Use a workspace-scoped API token config that incorrectly sets `ORGANIZATION_OBSERVE_MEMBER` as the role on a workspace entity; confirm Terraform still errors with a message that the role is not valid for that token type (same class of error as for `ORGANIZATION_OWNER`).
4. **Unit tests:** `go test ./internal/provider/common/... -count=1 -v` (covers `ValidateRoleMatchesEntityType`, including observe roles).
5. **Acceptance tests (optional, requires Hosted env):** Run the relevant `TestAcc_ResourceTeamRoles`, `TestAcc_ResourceUserRoles`, and API token acceptance tests with the repository’s documented environment variables.

```sh
Terraform will perform the following actions:

  # astro_user_roles.observe_admin will be created
  + resource "astro_user_roles" "observe_admin" {
      + organization_role = "ORGANIZATION_OBSERVE_ADMIN"
      + user_id           = "cmkrdpkkt1qwe01m05hhuvzhe"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

astro_user_roles.observe_admin: Creating...
astro_user_roles.observe_admin: Creation complete after 1s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [x] Added/updated applicable tests
- [x] Added/updated examples in the `examples/` directory
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
