### PR TITLE
`bug/astro-team-upgrade-organization-role`: Allowed update of Organizaton Role

### DIFF
--- a/internal/provider/resources/resource_team.go
+++ b/internal/provider/resources/resource_team.go
@@ -410,14 +410,13 @@ func (r *TeamResource) Update(
 		return
 	}
 
-	// Update team roles
-	if !data.WorkspaceRoles.IsNull() || !data.DeploymentRoles.IsNull() || !data.DagRoles.IsNull() {
+	// Always call MutateRoles to ensure organization_role is updated (updateTeam API only accepts name/description)
+	if !data.OrganizationRole.IsNull() || !data.WorkspaceRoles.IsNull() || !data.DeploymentRoles.IsNull() || !data.DagRoles.IsNull() {
 		diags = r.MutateRoles(ctx, &data, data.Id.ValueString())
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-
 	}
 
 	// Get Team and use this as data since it will have the correct roles

--- a/internal/provider/resources/resource_team_test.go
+++ b/internal/provider/resources/resource_team_test.go
@@ -267,6 +267,22 @@ func TestAcc_ResourceTeam(t *testing.T) {
 					testAccCheckTeamExistence(t, teamName, true),
 				),
 			},
+			// Update organization_role when no workspace or deployment roles are configured
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + team(teamInput{
+					Name:             teamName,
+					Description:      "updated to null members",
+					MemberIds:        []string{},
+					IncludeMemberIds: false,
+					OrganizationRole: string(iam.CreateTeamRequestOrganizationRoleORGANIZATIONMEMBER),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceVar, "organization_role", string(iam.CreateTeamRequestOrganizationRoleORGANIZATIONMEMBER)),
+					resource.TestCheckNoResourceAttr(resourceVar, "workspace_roles"),
+					resource.TestCheckNoResourceAttr(resourceVar, "deployment_roles"),
+					testAccCheckTeamExistence(t, teamName, true),
+				),
+			},
 			// Import existing team and check it is correctly imported
 			{
 				ResourceName:            resourceVar,


### PR DESCRIPTION
## Description

When updating the `organization_role` attribute in the `astro_team` resource, the change is silently ignored if the team has no `workspace_roles` or `deployment_roles` configured.
Terraform reports the apply as successful, but the organization role is not actually updated in Astro.

This PR resolves this behavior by allowing for the `organization_role` to be updated, even if no `workspace_roles` or `deployment_roles` are attached to it.

## 🎟 Issue(s)

Internal, Astronomer issue.

## 🧪 Functional Testing

```
terraform {
 required_providers {
   astro = {
     source = "astronomer/astro"
   }
 }
}

provider "astro" {
  organization_id = "<organization-id>"
}

# Create the team
resource "astro_team" "solutions_engineering_team" {
  name              = "Astronomer Solutions Engineering"
  organization_role = "ORGANIZATION_MEMBER"
}
```

## 📸 Screenshots

<img width="1142" height="392" alt="image" src="https://github.com/user-attachments/assets/67f45cb6-7f48-4c44-99e6-99f09fba0d9c" />


## 📋 Checklist

- [X] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
