### PR TITLE
Update examples & description for role hierarchy

### DIFF
--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -3,12 +3,12 @@
 page_title: "astro_team Resource - astro"
 subcategory: ""
 description: |-
-  Team resource
+  Creates and manages a team and its members. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
 ---
 
 # astro_team (Resource)
 
-Team resource
+Creates and manages a team and its members. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
 
 ## Example Usage
 
@@ -64,11 +64,11 @@ resource "astro_team" "imported_team" {
 
 ### Optional
 
-- `dag_roles` (Attributes Set) The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. (see [below for nested schema](#nestedatt--dag_roles))
-- `deployment_roles` (Attributes Set) The roles to assign to the Deployments (see [below for nested schema](#nestedatt--deployment_roles))
+- `dag_roles` (Attributes Set) The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (for example `DEPLOYMENT_ACCESSOR`). (see [below for nested schema](#nestedatt--dag_roles))
+- `deployment_roles` (Attributes Set) The roles to assign to the Deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`. (see [below for nested schema](#nestedatt--deployment_roles))
 - `description` (String) Team description
 - `member_ids` (Set of String) The IDs of the users to add to the Team
-- `workspace_roles` (Attributes Set) The roles to assign to the Workspaces (see [below for nested schema](#nestedatt--workspace_roles))
+- `workspace_roles` (Attributes Set) The roles to assign to the Workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API. (see [below for nested schema](#nestedatt--workspace_roles))
 
 ### Read-Only
 

--- a/docs/resources/team_roles.md
+++ b/docs/resources/team_roles.md
@@ -3,12 +3,12 @@
 page_title: "astro_team_roles Resource - astro"
 subcategory: ""
 description: |-
-  Team Roles resource
+  Manages organization, workspace, deployment, and DAG roles for an existing team. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
 ---
 
 # astro_team_roles (Resource)
 
-Team Roles resource
+Manages organization, workspace, deployment, and DAG roles for an existing team. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
 
 ## Example Usage
 
@@ -33,9 +33,17 @@ resource "astro_team_roles" "workspace_roles" {
   ]
 }
 
+# deployment_roles: include workspace_roles for each deployment's parent workspace
+# (any valid workspace role) so Terraform state matches stored roles.
 resource "astro_team_roles" "deployment_roles" {
   team_id           = "clnp86ly5000401ndaga21g81"
   organization_role = "ORGANIZATION_MEMBER"
+  workspace_roles = [
+    {
+      workspace_id = "clwp86ly5000401ndaga21g85"
+      role         = "WORKSPACE_MEMBER"
+    }
+  ]
   deployment_roles = [
     {
       deployment_id = "cldp86ly5000401ndaga21g86"
@@ -74,6 +82,12 @@ resource "astro_team_roles" "dag_roles" {
       role         = "WORKSPACE_MEMBER"
     }
   ]
+  deployment_roles = [
+    {
+      deployment_id = "cldp86ly5000401ndaga21g86"
+      role          = "DEPLOYMENT_ACCESSOR"
+    }
+  ]
   dag_roles = [
     {
       deployment_id = "cldp86ly5000401ndaga21g86"
@@ -90,6 +104,12 @@ resource "astro_team_roles" "dag_roles_with_tag" {
     {
       workspace_id = "clwp86ly5000401ndaga21g85"
       role         = "WORKSPACE_MEMBER"
+    }
+  ]
+  deployment_roles = [
+    {
+      deployment_id = "cldp86ly5000401ndaga21g86"
+      role          = "DEPLOYMENT_ACCESSOR"
     }
   ]
   dag_roles = [
@@ -134,8 +154,8 @@ resource "astro_team_roles" "imported_team_roles" {
 ### Optional
 
 - `dag_roles` (Attributes Set) The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (e.g. with `DEPLOYMENT_ACCESSOR` role). (see [below for nested schema](#nestedatt--dag_roles))
-- `deployment_roles` (Attributes Set) The roles to assign to the deployments. Required for any deployment referenced in `dag_roles`. (see [below for nested schema](#nestedatt--deployment_roles))
-- `workspace_roles` (Attributes Set) The roles to assign to the workspaces (see [below for nested schema](#nestedatt--workspace_roles))
+- `deployment_roles` (Attributes Set) The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`. (see [below for nested schema](#nestedatt--deployment_roles))
+- `workspace_roles` (Attributes Set) The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API. (see [below for nested schema](#nestedatt--workspace_roles))
 
 <a id="nestedatt--dag_roles"></a>
 ### Nested Schema for `dag_roles`

--- a/docs/resources/user_roles.md
+++ b/docs/resources/user_roles.md
@@ -3,12 +3,12 @@
 page_title: "astro_user_roles Resource - astro"
 subcategory: ""
 description: |-
-  User Roles resource
+  Manages organization, workspace, deployment, and DAG roles for a user. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
 ---
 
 # astro_user_roles (Resource)
 
-User Roles resource
+Manages organization, workspace, deployment, and DAG roles for a user. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
 
 ## Example Usage
 
@@ -29,9 +29,17 @@ resource "astro_user_roles" "workspace_roles" {
   ]
 }
 
+# deployment_roles: include workspace_roles for each deployment's parent workspace
+# (any valid workspace role) so Terraform state matches stored roles.
 resource "astro_user_roles" "deployment_roles" {
   user_id           = "clzaftcaz006001lhkey6qzzg"
   organization_role = "ORGANIZATION_MEMBER"
+  workspace_roles = [
+    {
+      workspace_id = "clx42sxw501gl01o0gjenthnh"
+      role         = "WORKSPACE_MEMBER"
+    }
+  ]
   deployment_roles = [
     {
       deployment_id = "clyn6kxud003x01mtxmccegnh"
@@ -70,6 +78,12 @@ resource "astro_user_roles" "dag_roles" {
       role         = "WORKSPACE_MEMBER"
     }
   ]
+  deployment_roles = [
+    {
+      deployment_id = "clyn6kxud003x01mtxmccegnh"
+      role          = "DEPLOYMENT_ACCESSOR"
+    }
+  ]
   dag_roles = [
     {
       deployment_id = "clyn6kxud003x01mtxmccegnh"
@@ -86,6 +100,12 @@ resource "astro_user_roles" "dag_roles_with_tag" {
     {
       workspace_id = "clx42sxw501gl01o0gjenthnh"
       role         = "WORKSPACE_MEMBER"
+    }
+  ]
+  deployment_roles = [
+    {
+      deployment_id = "clyn6kxud003x01mtxmccegnh"
+      role          = "DEPLOYMENT_ACCESSOR"
     }
   ]
   dag_roles = [
@@ -140,8 +160,8 @@ resource "astro_user_roles" "imported_user_roles" {
 ### Optional
 
 - `dag_roles` (Attributes Set) The DAG roles to assign to the user. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (e.g. with `DEPLOYMENT_ACCESSOR` role). (see [below for nested schema](#nestedatt--dag_roles))
-- `deployment_roles` (Attributes Set) The roles to assign to the deployments. Required for any deployment referenced in `dag_roles`. (see [below for nested schema](#nestedatt--deployment_roles))
-- `workspace_roles` (Attributes Set) The roles to assign to the workspaces (see [below for nested schema](#nestedatt--workspace_roles))
+- `deployment_roles` (Attributes Set) The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`. (see [below for nested schema](#nestedatt--deployment_roles))
+- `workspace_roles` (Attributes Set) The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API. (see [below for nested schema](#nestedatt--workspace_roles))
 
 <a id="nestedatt--dag_roles"></a>
 ### Nested Schema for `dag_roles`

--- a/examples/resources/astro_team_roles/resource.tf
+++ b/examples/resources/astro_team_roles/resource.tf
@@ -18,9 +18,17 @@ resource "astro_team_roles" "workspace_roles" {
   ]
 }
 
+# deployment_roles: include workspace_roles for each deployment's parent workspace
+# (any valid workspace role) so Terraform state matches stored roles.
 resource "astro_team_roles" "deployment_roles" {
   team_id           = "clnp86ly5000401ndaga21g81"
   organization_role = "ORGANIZATION_MEMBER"
+  workspace_roles = [
+    {
+      workspace_id = "clwp86ly5000401ndaga21g85"
+      role         = "WORKSPACE_MEMBER"
+    }
+  ]
   deployment_roles = [
     {
       deployment_id = "cldp86ly5000401ndaga21g86"
@@ -59,6 +67,12 @@ resource "astro_team_roles" "dag_roles" {
       role         = "WORKSPACE_MEMBER"
     }
   ]
+  deployment_roles = [
+    {
+      deployment_id = "cldp86ly5000401ndaga21g86"
+      role          = "DEPLOYMENT_ACCESSOR"
+    }
+  ]
   dag_roles = [
     {
       deployment_id = "cldp86ly5000401ndaga21g86"
@@ -75,6 +89,12 @@ resource "astro_team_roles" "dag_roles_with_tag" {
     {
       workspace_id = "clwp86ly5000401ndaga21g85"
       role         = "WORKSPACE_MEMBER"
+    }
+  ]
+  deployment_roles = [
+    {
+      deployment_id = "cldp86ly5000401ndaga21g86"
+      role          = "DEPLOYMENT_ACCESSOR"
     }
   ]
   dag_roles = [

--- a/examples/resources/astro_user_roles/resource.tf
+++ b/examples/resources/astro_user_roles/resource.tf
@@ -14,9 +14,17 @@ resource "astro_user_roles" "workspace_roles" {
   ]
 }
 
+# deployment_roles: include workspace_roles for each deployment's parent workspace
+# (any valid workspace role) so Terraform state matches stored roles.
 resource "astro_user_roles" "deployment_roles" {
   user_id           = "clzaftcaz006001lhkey6qzzg"
   organization_role = "ORGANIZATION_MEMBER"
+  workspace_roles = [
+    {
+      workspace_id = "clx42sxw501gl01o0gjenthnh"
+      role         = "WORKSPACE_MEMBER"
+    }
+  ]
   deployment_roles = [
     {
       deployment_id = "clyn6kxud003x01mtxmccegnh"
@@ -55,6 +63,12 @@ resource "astro_user_roles" "dag_roles" {
       role         = "WORKSPACE_MEMBER"
     }
   ]
+  deployment_roles = [
+    {
+      deployment_id = "clyn6kxud003x01mtxmccegnh"
+      role          = "DEPLOYMENT_ACCESSOR"
+    }
+  ]
   dag_roles = [
     {
       deployment_id = "clyn6kxud003x01mtxmccegnh"
@@ -71,6 +85,12 @@ resource "astro_user_roles" "dag_roles_with_tag" {
     {
       workspace_id = "clx42sxw501gl01o0gjenthnh"
       role         = "WORKSPACE_MEMBER"
+    }
+  ]
+  deployment_roles = [
+    {
+      deployment_id = "clyn6kxud003x01mtxmccegnh"
+      role          = "DEPLOYMENT_ACCESSOR"
     }
   ]
   dag_roles = [

--- a/internal/provider/resources/resource_team.go
+++ b/internal/provider/resources/resource_team.go
@@ -54,7 +54,7 @@ func (r *TeamResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "Team resource",
+		MarkdownDescription: "Creates and manages a team and its members. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.",
 		Attributes:          schemas.TeamResourceSchemaAttributes(),
 	}
 }

--- a/internal/provider/resources/resource_team_roles.go
+++ b/internal/provider/resources/resource_team_roles.go
@@ -55,7 +55,7 @@ func (r *teamRolesResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "Team Roles resource",
+		MarkdownDescription: "Manages organization, workspace, deployment, and DAG roles for an existing team. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.",
 		Attributes:          schemas.ResourceTeamRolesSchemaAttributes(),
 	}
 }

--- a/internal/provider/resources/resource_user_roles.go
+++ b/internal/provider/resources/resource_user_roles.go
@@ -53,7 +53,7 @@ func (r *UserRolesResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "User Roles resource",
+		MarkdownDescription: "Manages organization, workspace, deployment, and DAG roles for a user. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.",
 		Attributes:          schemas.ResourceUserRolesSchemaAttributes(),
 	}
 }

--- a/internal/provider/schemas/team.go
+++ b/internal/provider/schemas/team.go
@@ -136,21 +136,21 @@ func TeamResourceSchemaAttributes() map[string]resourceSchema.Attribute {
 				Attributes: ResourceWorkspaceRoleSchemaAttributes(),
 			},
 			Optional:            true,
-			MarkdownDescription: "The roles to assign to the Workspaces",
+			MarkdownDescription: "The roles to assign to the Workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.",
 		},
 		"deployment_roles": resourceSchema.SetNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: ResourceDeploymentRoleSchemaAttributes(),
 			},
 			Optional:            true,
-			MarkdownDescription: "The roles to assign to the Deployments",
+			MarkdownDescription: "The roles to assign to the Deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.",
 		},
 		"dag_roles": resourceSchema.SetNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: ResourceDagRoleSchemaAttributes(),
 			},
 			Optional:            true,
-			MarkdownDescription: "The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment.",
+			MarkdownDescription: "The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (for example `DEPLOYMENT_ACCESSOR`).",
 		},
 		"roles_count": resourceSchema.Int64Attribute{
 			MarkdownDescription: "Number of roles assigned to the Team",

--- a/internal/provider/schemas/team_roles.go
+++ b/internal/provider/schemas/team_roles.go
@@ -3,7 +3,6 @@ package schemas
 import (
 	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
 	"github.com/astronomer/terraform-provider-astro/internal/provider/validators"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,9 +36,6 @@ func ResourceTeamRolesSchemaAttributes() map[string]resourceSchema.Attribute {
 			},
 			Optional:            true,
 			MarkdownDescription: "The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.",
-			Validators: []validator.Set{
-				setvalidator.SizeAtLeast(1),
-			},
 		},
 		"deployment_roles": resourceSchema.SetNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{
@@ -47,9 +43,6 @@ func ResourceTeamRolesSchemaAttributes() map[string]resourceSchema.Attribute {
 			},
 			Optional:            true,
 			MarkdownDescription: "The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.",
-			Validators: []validator.Set{
-				setvalidator.SizeAtLeast(1),
-			},
 		},
 		"dag_roles": resourceSchema.SetNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{

--- a/internal/provider/schemas/team_roles.go
+++ b/internal/provider/schemas/team_roles.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
 	"github.com/astronomer/terraform-provider-astro/internal/provider/validators"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -35,14 +36,20 @@ func ResourceTeamRolesSchemaAttributes() map[string]resourceSchema.Attribute {
 				Attributes: ResourceWorkspaceRoleSchemaAttributes(),
 			},
 			Optional:            true,
-			MarkdownDescription: "The roles to assign to the workspaces",
+			MarkdownDescription: "The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+			},
 		},
 		"deployment_roles": resourceSchema.SetNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: ResourceDeploymentRoleSchemaAttributes(),
 			},
 			Optional:            true,
-			MarkdownDescription: "The roles to assign to the deployments. Required for any deployment referenced in `dag_roles`.",
+			MarkdownDescription: "The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+			},
 		},
 		"dag_roles": resourceSchema.SetNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{

--- a/internal/provider/schemas/user_roles.go
+++ b/internal/provider/schemas/user_roles.go
@@ -36,7 +36,7 @@ func ResourceUserRolesSchemaAttributes() map[string]resourceSchema.Attribute {
 				Attributes: ResourceWorkspaceRoleSchemaAttributes(),
 			},
 			Optional:            true,
-			MarkdownDescription: "The roles to assign to the workspaces",
+			MarkdownDescription: "The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.",
 			Validators: []validator.Set{
 				setvalidator.SizeAtLeast(1),
 			},
@@ -46,7 +46,7 @@ func ResourceUserRolesSchemaAttributes() map[string]resourceSchema.Attribute {
 				Attributes: ResourceDeploymentRoleSchemaAttributes(),
 			},
 			Optional:            true,
-			MarkdownDescription: "The roles to assign to the deployments. Required for any deployment referenced in `dag_roles`.",
+			MarkdownDescription: "The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.",
 			Validators: []validator.Set{
 				setvalidator.SizeAtLeast(1),
 			},


### PR DESCRIPTION
## Description
Updates terraform-provider-astro docs and examples for `astro_team_roles`, `astro_user_roles`, and `astro_team` so they match provider validation and the hierarchical IAM model (org → workspace → deployment → DAG). Examples now include parent workspace roles with deployment roles and deployment roles with DAG roles. Schema copy is shorter and clearer; generated registry docs refreshed via `go generate`.

## 🎟 Issue(s)


## 🧪 Functional Testing
- `go generate ./...` in terraform-provider-astro
- `go test ./internal/provider/...` (non-acc)
- 
## 📸 Screenshots
N/A (docs and examples only)

## 📋 Checklist
- [ ] Added/updated applicable tests
- [x] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)