### PR TITLE
Add support for AWS secondary_vpc_cidr

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -50,6 +50,7 @@ output "cluster" {
 - `provider_account` (String) Cluster provider account
 - `region` (String) Cluster region
 - `service_peering_range` (String) Cluster service peering range
+- `secondary_vpc_cidr` (String) Secondary CIDR for pod networking (AWS only)
 - `service_subnet_range` (String) Cluster service subnet range
 - `status` (String) Cluster status
 - `tags` (Attributes Set) Cluster tags (see [below for nested schema](#nestedatt--tags))

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -49,8 +49,8 @@ output "cluster" {
 - `pod_subnet_range` (String) Cluster pod subnet range
 - `provider_account` (String) Cluster provider account
 - `region` (String) Cluster region
-- `service_peering_range` (String) Cluster service peering range
 - `secondary_vpc_cidr` (String) Secondary CIDR for pod networking (AWS only)
+- `service_peering_range` (String) Cluster service peering range
 - `service_subnet_range` (String) Cluster service subnet range
 - `status` (String) Cluster status
 - `tags` (Attributes Set) Cluster tags (see [below for nested schema](#nestedatt--tags))

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -68,6 +68,7 @@ Read-Only:
 - `provider_account` (String) Cluster provider account
 - `region` (String) Cluster region
 - `service_peering_range` (String) Cluster service peering range
+- `secondary_vpc_cidr` (String) Secondary CIDR for pod networking (AWS only)
 - `service_subnet_range` (String) Cluster service subnet range
 - `status` (String) Cluster status
 - `tags` (Attributes Set) Cluster tags (see [below for nested schema](#nestedatt--clusters--tags))

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -67,8 +67,8 @@ Read-Only:
 - `pod_subnet_range` (String) Cluster pod subnet range
 - `provider_account` (String) Cluster provider account
 - `region` (String) Cluster region
-- `service_peering_range` (String) Cluster service peering range
 - `secondary_vpc_cidr` (String) Secondary CIDR for pod networking (AWS only)
+- `service_peering_range` (String) Cluster service peering range
 - `service_subnet_range` (String) Cluster service subnet range
 - `status` (String) Cluster status
 - `tags` (Attributes Set) Cluster tags (see [below for nested schema](#nestedatt--clusters--tags))

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -14,12 +14,13 @@ Cluster resource. If creating multiple clusters, add a delay between each cluste
 
 ```terraform
 resource "astro_cluster" "aws_example" {
-  type             = "DEDICATED"
-  name             = "my first aws cluster"
-  region           = "us-east-1"
-  cloud_provider   = "AWS"
-  vpc_subnet_range = "172.20.0.0/20"
-  workspace_ids    = []
+  type               = "DEDICATED"
+  name               = "my first aws cluster"
+  region             = "us-east-1"
+  cloud_provider     = "AWS"
+  vpc_subnet_range   = "172.20.0.0/20"
+  secondary_vpc_cidr = "100.64.0.0/19" # Optional: secondary CIDR for pod networking
+  workspace_ids      = []
   timeouts = {    # Optional timeouts for create, update, and delete
     create = "3h" # Timeout after 3 hours if the cluster is not created
     update = "2h" # Timeout after 2 hours if the cluster is not updated
@@ -99,6 +100,7 @@ resource "astro_cluster" "imported_cluster" {
 - `is_dr_enabled` (Boolean) Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.
 - `is_failed_over` (Boolean) Whether the cluster is currently failed over to the DR region. Set to `true` to trigger failover; set to `false` to fail back.
 - `pod_subnet_range` (String) Cluster pod subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
+- `secondary_vpc_cidr` (String) Secondary CIDR for pod networking (AWS only, /16 to /20). Cannot be changed once set.
 - `service_peering_range` (String) Cluster service peering range - required for 'GCP' clusters. If changed, the cluster will be recreated.
 - `service_subnet_range` (String) Cluster service subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/examples/resources/astro_cluster/resource.tf
+++ b/examples/resources/astro_cluster/resource.tf
@@ -1,10 +1,11 @@
 resource "astro_cluster" "aws_example" {
-  type             = "DEDICATED"
-  name             = "my first aws cluster"
-  region           = "us-east-1"
-  cloud_provider   = "AWS"
-  vpc_subnet_range = "172.20.0.0/20"
-  workspace_ids    = []
+  type               = "DEDICATED"
+  name               = "my first aws cluster"
+  region             = "us-east-1"
+  cloud_provider     = "AWS"
+  vpc_subnet_range   = "172.20.0.0/20"
+  secondary_vpc_cidr = "100.64.0.0/19" # Optional: secondary CIDR for pod networking
+  workspace_ids      = []
   timeouts = {    # Optional timeouts for create, update, and delete
     create = "3h" # Timeout after 3 hours if the cluster is not created
     update = "2h" # Timeout after 2 hours if the cluster is not updated

--- a/internal/provider/models/cluster.go
+++ b/internal/provider/models/cluster.go
@@ -24,6 +24,7 @@ type ClusterResource struct {
 	ServicePeeringRange          types.String   `tfsdk:"service_peering_range"`
 	ServiceSubnetRange           types.String   `tfsdk:"service_subnet_range"`
 	VpcSubnetRange               types.String   `tfsdk:"vpc_subnet_range"`
+	SecondaryVpcCidr             types.String   `tfsdk:"secondary_vpc_cidr"`
 	Metadata                     types.Object   `tfsdk:"metadata"`
 	Status                       types.String   `tfsdk:"status"`
 	CreatedAt                    types.String   `tfsdk:"created_at"`
@@ -55,6 +56,7 @@ type ClusterDataSource struct {
 	ServicePeeringRange          types.String `tfsdk:"service_peering_range"`
 	ServiceSubnetRange           types.String `tfsdk:"service_subnet_range"`
 	VpcSubnetRange               types.String `tfsdk:"vpc_subnet_range"`
+	SecondaryVpcCidr             types.String `tfsdk:"secondary_vpc_cidr"`
 	Metadata                     types.Object `tfsdk:"metadata"`
 	Status                       types.String `tfsdk:"status"`
 	CreatedAt                    types.String `tfsdk:"created_at"`
@@ -127,6 +129,7 @@ func (data *ClusterResource) ReadFromResponse(
 	data.ServicePeeringRange = types.StringPointerValue(cluster.ServicePeeringRange)
 	data.ServiceSubnetRange = types.StringPointerValue(cluster.ServiceSubnetRange)
 	data.VpcSubnetRange = types.StringValue(cluster.VpcSubnetRange)
+	data.SecondaryVpcCidr = types.StringPointerValue(cluster.SecondaryVpcCidr)
 	data.Metadata, diags = ClusterMetadataTypesObject(ctx, cluster.Metadata)
 	if diags.HasError() {
 		return diags
@@ -188,6 +191,7 @@ func (data *ClusterDataSource) ReadFromResponse(
 	data.ServicePeeringRange = types.StringPointerValue(cluster.ServicePeeringRange)
 	data.ServiceSubnetRange = types.StringPointerValue(cluster.ServiceSubnetRange)
 	data.VpcSubnetRange = types.StringValue(cluster.VpcSubnetRange)
+	data.SecondaryVpcCidr = types.StringPointerValue(cluster.SecondaryVpcCidr)
 	data.Metadata, diags = ClusterMetadataTypesObject(ctx, cluster.Metadata)
 	if diags.HasError() {
 		return diags

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -101,6 +101,7 @@ func (r *ClusterResource) Create(
 			Region:                       data.Region.ValueString(),
 			Type:                         platform.CreateAwsClusterRequestType(data.Type.ValueString()),
 			VpcSubnetRange:               data.VpcSubnetRange.ValueString(),
+			SecondaryVpcCidr:             data.SecondaryVpcCidr.ValueStringPointer(),
 			DrRegion:                     data.DrRegion.ValueStringPointer(),
 			DrVpcSubnetRange:             data.DrVpcSubnetRange.ValueStringPointer(),
 			DrSecondaryVpcCidr:           data.DrSecondaryVpcCidr.ValueStringPointer(),
@@ -610,6 +611,14 @@ func validateAzureConfig(ctx context.Context, data *models.ClusterResource) diag
 		)
 	}
 
+	// secondary_vpc_cidr is AWS only
+	if !data.SecondaryVpcCidr.IsNull() {
+		diags.AddError(
+			"secondary_vpc_cidr is not allowed for 'AZURE' cluster",
+			"Please remove secondary_vpc_cidr",
+		)
+	}
+
 	// DR is not supported for Azure clusters
 	if !data.IsDrEnabled.IsNull() && data.IsDrEnabled.ValueBool() {
 		diags.AddError(
@@ -673,6 +682,12 @@ func validateGcpConfig(ctx context.Context, data *models.ClusterResource) diag.D
 		diags.AddError(
 			"tenant_id is not allowed for 'GCP' cluster",
 			"Please remove tenant_id",
+		)
+	}
+	if !data.SecondaryVpcCidr.IsNull() {
+		diags.AddError(
+			"secondary_vpc_cidr is not allowed for 'GCP' cluster",
+			"Please remove secondary_vpc_cidr",
 		)
 	}
 

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -789,6 +789,7 @@ type clusterInput struct {
 	Region                             string
 	CloudProvider                      string
 	RestrictedWorkspaceResourceVarName string
+	SecondaryVpcCidr                   string
 	IsDrEnabled                        bool
 	DrRegion                           string
 	DrVpcSubnetRange                   string
@@ -807,6 +808,11 @@ func cluster(input clusterInput) string {
 	pod_subnet_range = "172.21.0.0/19"
 	service_peering_range = "172.23.0.0/20"
 	service_subnet_range =  "172.22.0.0/22"`
+	}
+	secondaryVpcCidrField := ""
+	if input.SecondaryVpcCidr != "" {
+		secondaryVpcCidrField = fmt.Sprintf(`
+	secondary_vpc_cidr = "%v"`, input.SecondaryVpcCidr)
 	}
 	drFields := ""
 	if input.IsDrEnabled {
@@ -834,9 +840,10 @@ func cluster(input clusterInput) string {
 	vpc_subnet_range = "172.20.0.0/20"
 	%v
 	%v
+	%v
 	workspace_ids = [%v]
 }
-`, input.Name, input.Name, input.Region, input.CloudProvider, gcpNetworkFields, drFields, workspaceId)
+`, input.Name, input.Name, input.Region, input.CloudProvider, gcpNetworkFields, secondaryVpcCidrField, drFields, workspaceId)
 }
 
 func clusterWithVariableName(input clusterInput) string {

--- a/internal/provider/schemas/cluster.go
+++ b/internal/provider/schemas/cluster.go
@@ -91,6 +91,11 @@ func ClusterResourceSchemaAttributes(ctx context.Context) map[string]resourceSch
 				stringplanmodifier.RequiresReplaceIfConfigured(),
 			},
 		},
+		"secondary_vpc_cidr": resourceSchema.StringAttribute{
+			MarkdownDescription: "Secondary CIDR for pod networking (AWS only, /16 to /20). Cannot be changed once set.",
+			Optional:            true,
+			Computed:            true,
+		},
 		"metadata": resourceSchema.SingleNestedAttribute{
 			Attributes:          ClusterMetadataResourceAttributes(),
 			Computed:            true,
@@ -245,6 +250,10 @@ func ClusterDataSourceSchemaAttributes() map[string]datasourceSchema.Attribute {
 		},
 		"vpc_subnet_range": datasourceSchema.StringAttribute{
 			MarkdownDescription: "Cluster VPC subnet range",
+			Computed:            true,
+		},
+		"secondary_vpc_cidr": datasourceSchema.StringAttribute{
+			MarkdownDescription: "Secondary CIDR for pod networking (AWS only)",
 			Computed:            true,
 		},
 		"metadata": datasourceSchema.SingleNestedAttribute{

--- a/internal/provider/schemas/clusters.go
+++ b/internal/provider/schemas/clusters.go
@@ -24,6 +24,7 @@ func ClustersElementAttributeTypes() map[string]attr.Type {
 		"service_peering_range": types.StringType,
 		"service_subnet_range":  types.StringType,
 		"vpc_subnet_range":      types.StringType,
+		"secondary_vpc_cidr":    types.StringType,
 		"metadata": types.ObjectType{
 			AttrTypes: ClusterMetadataAttributeTypes(),
 		},


### PR DESCRIPTION
## Description

Adds support for specifying `secondary_vpc_cidr` during creation of AWS clusters

## 🎟 Issue(s)

## 🧪 Functional Testing

Tested cluster creation specifying the new field:

```
resource "astro_cluster" "aws_secondary_cidr_tf_test" {
  type                = "DEDICATED"
  name                = "aws_secondary_cidr_tf_test"
  region              = "us-east-1"
  cloud_provider      = "AWS"
  vpc_subnet_range    = "172.20.0.0/20"
  secondary_vpc_cidr  = "100.64.0.0/16"
  workspace_ids       = []
}
```

## 📸 Screenshots

<img width="950" height="340" alt="image" src="https://github.com/user-attachments/assets/9c0f0c1e-4b15-48c5-99f7-e037e0134638" />



## 📋 Checklist

- [x] Added/updated applicable tests
- [x] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
