### PR TITLE
Fix inconsistent result for remote_execution.allowed_ip_address_ranges CPP-527

### DIFF
--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -78,12 +78,13 @@ func TestAcc_ResourceClusterAwsWithDedicatedDeployments(t *testing.T) {
 						SchedulerSize: "SMALL",
 					}) +
 					dedicatedRemoteDeployment(dedicatedRemoteDeploymentInput{
-						ClusterId:     awsResourceVarId,
-						WorkspaceId:   workspaceResourceVarId,
-						Name:          awsDeploymentName,
-						Description:   "deployment description",
-						Executor:      "ASTRO",
-						TaskLogBucket: "s3://my-task-log-bucket",
+						ClusterId:              awsResourceVarId,
+						WorkspaceId:            workspaceResourceVarId,
+						Name:                   awsDeploymentName,
+						Description:            "deployment description",
+						Executor:               "ASTRO",
+						TaskLogBucket:          "s3://my-task-log-bucket",
+						AllowedIpAddressRanges: []string{"8.8.8.8/32"},
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					// Check cluster
@@ -290,12 +291,13 @@ func TestAcc_ResourceClusterAzureWithDedicatedDeployments(t *testing.T) {
 						SchedulerSize: "SMALL",
 					}) +
 					dedicatedRemoteDeployment(dedicatedRemoteDeploymentInput{
-						ClusterId:         azureResourceVarId,
-						WorkspaceId:       workspaceResourceVarId,
-						Name:              azureDeploymentName,
-						Description:       utils.TestResourceDescription,
-						Executor:          "ASTRO",
-						TaskLogUrlPattern: "https://s3.amazonaws.com/my-task-log-bucket/{{ task_id }}/{{ execution_date }}/{{ filename }}",
+						ClusterId:              azureResourceVarId,
+						WorkspaceId:            workspaceResourceVarId,
+						Name:                   azureDeploymentName,
+						Description:            utils.TestResourceDescription,
+						Executor:               "ASTRO",
+						TaskLogUrlPattern:      "https://s3.amazonaws.com/my-task-log-bucket/{{ task_id }}/{{ execution_date }}/{{ filename }}",
+						AllowedIpAddressRanges: []string{"8.8.8.8/32"},
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					// Check cluster
@@ -397,11 +399,12 @@ func TestAcc_ResourceClusterGcpWithDedicatedDeployments(t *testing.T) {
 						SchedulerSize: "SMALL",
 					}) +
 					dedicatedRemoteDeployment(dedicatedRemoteDeploymentInput{
-						ClusterId:   gcpResourceVarId,
-						WorkspaceId: workspaceResourceVarId,
-						Name:        gcpDeploymentName,
-						Description: utils.TestResourceDescription,
-						Executor:    "ASTRO",
+						ClusterId:              gcpResourceVarId,
+						WorkspaceId:            workspaceResourceVarId,
+						Name:                   gcpDeploymentName,
+						Description:            utils.TestResourceDescription,
+						Executor:               "ASTRO",
+						AllowedIpAddressRanges: []string{"8.8.8.8/32"},
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					// Check cluster
@@ -748,6 +751,10 @@ type dedicatedRemoteDeploymentInput struct {
 	Executor          string
 	TaskLogBucket     string
 	TaskLogUrlPattern string
+	// AllowedIpAddressRanges controls the `allowed_ip_address_ranges` HCL field.
+	// nil or empty → field is omitted from HCL entirely (regression case for GH #244).
+	// non-empty → field is emitted with the given CIDRs.
+	AllowedIpAddressRanges []string
 }
 
 func dedicatedRemoteDeployment(input dedicatedRemoteDeploymentInput) string {
@@ -758,6 +765,14 @@ func dedicatedRemoteDeployment(input dedicatedRemoteDeploymentInput) string {
 	var taskLogUrlPatternStr string
 	if input.TaskLogUrlPattern != "" {
 		taskLogUrlPatternStr = fmt.Sprintf(`task_log_url_pattern = "%s"`, input.TaskLogUrlPattern)
+	}
+	var allowedIpRangesStr string
+	if len(input.AllowedIpAddressRanges) > 0 {
+		quoted := make([]string, len(input.AllowedIpAddressRanges))
+		for i, ip := range input.AllowedIpAddressRanges {
+			quoted[i] = fmt.Sprintf(`"%s"`, ip)
+		}
+		allowedIpRangesStr = fmt.Sprintf(`allowed_ip_address_ranges = [%s]`, strings.Join(quoted, ", "))
 	}
 	return fmt.Sprintf(`
 resource "astro_deployment" "%v_remote" {
@@ -776,12 +791,12 @@ resource "astro_deployment" "%v_remote" {
 	environment_variables = []
 	remote_execution = {
 		enabled = true
-		allowed_ip_address_ranges = ["8.8.8.8/32"]
+		%s
 		%s
 		%s
 	}
 }
-`, input.Name, input.Name, input.Description, input.ClusterId, input.Executor, input.WorkspaceId, taskLogBucketStr, taskLogUrlPatternStr)
+`, input.Name, input.Name, input.Description, input.ClusterId, input.Executor, input.WorkspaceId, allowedIpRangesStr, taskLogBucketStr, taskLogUrlPatternStr)
 }
 
 type clusterInput struct {

--- a/internal/provider/resources/resource_deployment_test.go
+++ b/internal/provider/resources/resource_deployment_test.go
@@ -187,12 +187,13 @@ func TestAcc_ResourceDeploymentDedicated(t *testing.T) {
 						SchedulerSize: "SMALL",
 					}) +
 					dedicatedRemoteDeployment(dedicatedRemoteDeploymentInput{
-						ClusterId:     clusterId,
-						WorkspaceId:   workspaceId,
-						Name:          deploymentName,
-						Description:   "deployment description",
-						Executor:      "ASTRO",
-						TaskLogBucket: "s3://my-task-log-bucket",
+						ClusterId:              clusterId,
+						WorkspaceId:            workspaceId,
+						Name:                   deploymentName,
+						Description:            "deployment description",
+						Executor:               "ASTRO",
+						TaskLogBucket:          "s3://my-task-log-bucket",
+						AllowedIpAddressRanges: []string{"8.8.8.8/32"},
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					// Check dedicated deployment
@@ -219,6 +220,72 @@ func TestAcc_ResourceDeploymentDedicated(t *testing.T) {
 					testAccCheckDeploymentExistence(t, deploymentName, true, true),
 					testAccCheckDeploymentExistence(t, deploymentName+"_astro", true, true),
 					testAccCheckDeploymentExistence(t, deploymentName+"_remote", true, true),
+				),
+			},
+		},
+	})
+}
+
+// TestAcc_ResourceDeploymentRemoteExecutionAllowedIPRanges regresses GH #244.
+// The Astro API always returns `allowedIpAddressRanges` as an array (empty `[]` when unset
+// rather than null). When this field was Optional-only, omitting it from HCL caused
+// "Provider produced inconsistent result after apply: was null, but now cty.SetValEmpty(cty.String)".
+//
+// Steps:
+//  1. Create the remote deployment without `allowed_ip_address_ranges` — must succeed in
+//     one apply and the implicit post-apply plan must be empty.
+//  2. Update to a multi-element list — round-trip preserves both values; plan empty.
+func TestAcc_ResourceDeploymentRemoteExecutionAllowedIPRanges(t *testing.T) {
+	namePrefix := utils.GenerateTestResourceName(10)
+
+	workspaceName := fmt.Sprintf("%v_workspace", namePrefix)
+	workspaceResourceVar := fmt.Sprintf("astro_workspace.%v", workspaceName)
+	workspaceId := fmt.Sprintf("%v.id", workspaceResourceVar)
+
+	clusterId := fmt.Sprintf("\"%v\"", os.Getenv("HOSTED_DEDICATED_CLUSTER_ID"))
+	deploymentName := fmt.Sprintf("%v_remote_ips", namePrefix)
+	resourceVar := fmt.Sprintf("astro_deployment.%v_remote", deploymentName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckDeploymentExistence(t, deploymentName+"_remote", true, false),
+		),
+		Steps: []resource.TestStep{
+			// Step 1: create without allowed_ip_address_ranges — bug fired here before the fix.
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					workspace(workspaceName, workspaceName, utils.TestResourceDescription, false) +
+					dedicatedRemoteDeployment(dedicatedRemoteDeploymentInput{
+						ClusterId:   clusterId,
+						WorkspaceId: workspaceId,
+						Name:        deploymentName,
+						Description: "deployment description",
+						Executor:    "ASTRO",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceVar, "remote_execution.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceVar, "remote_execution.allowed_ip_address_ranges.#", "0"),
+					testAccCheckDeploymentExistence(t, deploymentName+"_remote", true, true),
+				),
+			},
+			// Step 2: update to multiple IPs — round-trip preserves both.
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					workspace(workspaceName, workspaceName, utils.TestResourceDescription, false) +
+					dedicatedRemoteDeployment(dedicatedRemoteDeploymentInput{
+						ClusterId:              clusterId,
+						WorkspaceId:            workspaceId,
+						Name:                   deploymentName,
+						Description:            "deployment description",
+						Executor:               "ASTRO",
+						AllowedIpAddressRanges: []string{"10.0.0.0/8", "192.168.1.0/24"},
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceVar, "remote_execution.allowed_ip_address_ranges.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceVar, "remote_execution.allowed_ip_address_ranges.*", "10.0.0.0/8"),
+					resource.TestCheckTypeSetElemAttr(resourceVar, "remote_execution.allowed_ip_address_ranges.*", "192.168.1.0/24"),
 				),
 			},
 		},

--- a/internal/provider/schemas/remote_execution.go
+++ b/internal/provider/schemas/remote_execution.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -63,7 +66,18 @@ func RemoteExecutionResourceSchemaAttributes() map[string]resourceSchema.Attribu
 		"allowed_ip_address_ranges": resourceSchema.SetAttribute{
 			MarkdownDescription: "The allowed IP address ranges for remote execution",
 			Optional:            true,
-			ElementType:         types.StringType,
+			// The API always returns this field as an array (empty `[]` when unset rather than null),
+			// so the schema must be `Computed` with an empty-set default. Without this, omitting the
+			// field in HCL produces "Provider produced inconsistent result after apply: was null,
+			// but now cty.SetValEmpty(cty.String)." See GH #244.
+			Computed:    true,
+			ElementType: types.StringType,
+			Default: setdefault.StaticValue(
+				types.SetValueMust(types.StringType, []attr.Value{}),
+			),
+			PlanModifiers: []planmodifier.Set{
+				setplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"remote_api_url": resourceSchema.StringAttribute{
 			MarkdownDescription: "The URL for the remote API",


### PR DESCRIPTION
## Description

When creating a deployment with `remote_execution.enabled = true` and the
`allowed_ip_address_ranges` field **omitted** from HCL, Terraform fails with:

```
Error: Provider produced inconsistent result after apply

When applying changes to astro_deployment.<name>, provider
"provider[\"registry.terraform.io/astronomer/astro\"]" produced an unexpected
new value: .remote_execution.allowed_ip_address_ranges: was null, but now
cty.SetValEmpty(cty.String).
```

A second `terraform apply` settles the state, but the first apply error blocks
users from creating remote-execution deployments via Terraform unless they
explicitly set `allowed_ip_address_ranges`.

### Root cause

The Astro API always returns `allowedIpAddressRanges` as an array (empty `[]`
when unset rather than `null`). The provider, however, sent the field via
`*[]string` with `omitempty` and declared the schema attribute `Optional`-only.

So when a user omitted the field in HCL:

- Terraform plan: `allowed_ip_address_ranges = null`
- API stores `nil`, returns `[]`
- Provider sets state to empty set
- Plan (`null`) ≠ state (`[]`) → Terraform rejects the apply

### Fix

Align the resource schema with the API contract. Mark
`remote_execution.allowed_ip_address_ranges` as `Computed` with an empty-set
default and add `UseStateForUnknown` for updates. Plan and post-apply state
now both resolve to `[]` when the user omits the field.

```go
"allowed_ip_address_ranges": resourceSchema.SetAttribute{
    MarkdownDescription: "The allowed IP address ranges for remote execution",
    Optional:            true,
    Computed:            true,
    ElementType:         types.StringType,
    Default: setdefault.StaticValue(
        types.SetValueMust(types.StringType, []attr.Value{}),
    ),
    PlanModifiers: []planmodifier.Set{
        setplanmodifier.UseStateForUnknown(),
    },
},
```

**Behavior note for users:** This fix codifies the API’s actual semantics for allowed_ip_address_ranges: the API always returns an array (never null), and once a deployment exists, the field has a value. With UseStateForUnknown, removing the field from HCL after it was set is a no-op (prior value is preserved). To clear, set explicitly to []. Previously, both operations triggered the inconsistent-result error — there was no working “remove to clear” path, so this isn’t a behavior regression

## 🎟 Issue(s)

Fixes internal astronomer issue

## 🧪 Functional Testing

Tested end-to-end using a
`dev_overrides` build of the branch, with the same exact reproduction config
from #244.

### Reproduction (before the fix) — confirms the bug exists on `main`

Built the provider from `main` (commit `366d28e`) and ran:

```hcl
resource "astro_deployment" "bug_repro" {
  name                  = "cpp527-bug-repro"
  type                  = "DEDICATED"
  cluster_id            = "<dedicated-cluster-id>"
  workspace_id          = "<workspace-id>"
  contact_emails        = []
  executor              = "ASTRO"
  is_cicd_enforced      = true
  is_dag_deploy_enabled = false
  is_development_mode   = false
  is_high_availability  = false
  scheduler_size        = "SMALL"
  environment_variables = []
  remote_execution = {
    enabled = true
    # allowed_ip_address_ranges intentionally omitted
  }
}
```

Result:

```
astro_deployment.bug_repro: Creating...

Error: Provider produced inconsistent result after apply

When applying changes to astro_deployment.bug_repro, provider
"provider[\"registry.terraform.io/astronomer/astro\"]" produced an unexpected
new value: .remote_execution.allowed_ip_address_ranges: was null, but now
cty.SetValEmpty(cty.String).
```

### Verification (after the fix) — same HCL, same dev environment

Built the provider from this branch and ran the same apply.

Plan diff for the `remote_execution` block now shows the default:

```
+ remote_execution = {
    + allowed_ip_address_ranges = []
    + enabled                   = true
    + remote_api_url            = (known after apply)
  }
```

Apply output:

```
astro_deployment.cpp527_probe: Creating...
astro_deployment.cpp527_probe: Creation complete after 2s [id=cmp2wqygn000101kivb2aji0t]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Second `terraform plan` confirms idempotency:

```
No changes. Your infrastructure matches the configuration.
Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

### Both runs visible on dev via `astro deployment list`

```
 NAME                 CLUSTER           CLOUD PROVIDER     REGION      DEPLOYMENT ID                 DEPLOYMENT TYPE     REMOTE EXECUTION
 cpp527-probe         testTerraform     AZURE              westus2     cmp2wqygn000101kivb2aji0t     DEDICATED           true
 cpp527-bug-repro     testTerraform     AZURE              westus2     cmp2x5eet00af01lmbhkvba3q     DEDICATED           true
```

`cpp527-probe` was created cleanly by the fixed provider. `cpp527-bug-repro`
is the orphan created by the buggy provider on `main` — Astro accepted the
API call and created the deployment, but Terraform rejected the response with
the inconsistent-result error before recording it in state. 

### Side-by-side

| Provider | Plan diff for `allowed_ip_address_ranges` | Apply result |
|---|---|---|
| `main` (pre-fix) | line absent (planned as `null`) | ❌ Provider produced inconsistent result after apply |
| This branch | `+ allowed_ip_address_ranges = []` | ✅ created in 2s, idempotent on replan |

### Acceptance test

Added `TestAcc_ResourceDeploymentRemoteExecutionAllowedIPRanges` in
`internal/provider/resources/resource_deployment_test.go`:

- **Step 1:** create a remote-execution deployment with
  `allowed_ip_address_ranges` omitted — asserts the apply succeeds in one
  shot and the implicit post-apply plan is empty.
- **Step 2:** update the same deployment to a multi-element list
  (`["10.0.0.0/8", "192.168.1.0/24"]`) — asserts both values round-trip
  faithfully and plan is empty.

Existing acceptance tests that exercise the field
(`TestAcc_ResourceDeploymentDedicated`, AWS/Azure/GCP cluster suites) updated
to pass the IP list explicitly through the test helper rather than relying on
the previous helper's hard-coded default.

## 📸 Screenshots

N/A — schema-level fix with no UI changes.

## 📋 Checklist

- [x] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory _(existing examples already cover this field)_
- [x] Updated any related [documentation](https://github.com/astronomer/docs/) _(provider docs regenerated via `go generate`)_