### PR TITLE
`fix/paginate-list-deployments`: Paginating through Deployment listing …

### DIFF
--- a/internal/provider/common/role.go
+++ b/internal/provider/common/role.go
@@ -118,6 +118,7 @@ type ValidateWorkspaceDeploymentRolesInput struct {
 	OrganizationId  string
 	DeploymentRoles []iam.DeploymentRole
 	WorkspaceRoles  []iam.WorkspaceRole
+	Limit           int // page size for ListDeployments; defaults to 1000 if zero
 }
 
 // ValidateWorkspaceDeploymentRoles checks if deployment roles have corresponding workspace roles
@@ -133,10 +134,15 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 	})
 	deploymentRoleIds = lo.Uniq(deploymentRoleIds)
 
+	limit := input.Limit
+	if limit == 0 {
+		limit = 1000
+	}
+
 	// get list of deployments (paginated)
 	params := &platform.ListDeploymentsParams{
 		DeploymentIds: &deploymentRoleIds,
-		Limit:         lo.ToPtr(100),
+		Limit:         lo.ToPtr(limit),
 	}
 
 	var queriedDeployments []platform.Deployment

--- a/internal/provider/common/role.go
+++ b/internal/provider/common/role.go
@@ -160,6 +160,11 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 			)}
 		}
 
+		_, diagnostic := clients.NormalizeAPIError(ctx, listDeployments.HTTPResponse, listDeployments.Body)
+		if diagnostic != nil {
+			return diag.Diagnostics{diagnostic}
+		}
+
 		if listDeployments.JSON200 == nil {
 			return diag.Diagnostics{diag.NewErrorDiagnostic(
 				"Client Error", "Unable to list deployments, got nil response")}
@@ -168,11 +173,6 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 		// Handle an empty page, breaking early
 		if len(listDeployments.JSON200.Deployments) == 0 {
 			break
-		}
-
-		_, diagnostic := clients.NormalizeAPIError(ctx, listDeployments.HTTPResponse, listDeployments.Body)
-		if diagnostic != nil {
-			return diag.Diagnostics{diagnostic}
 		}
 
 		// Append new Deployments to queriedDeployments, which we'll eventually use to validate Deployment ID's

--- a/internal/provider/common/role.go
+++ b/internal/provider/common/role.go
@@ -114,7 +114,7 @@ func ValidateRoleMatchesEntityType(role string, scopeType string) bool {
 }
 
 type ValidateWorkspaceDeploymentRolesInput struct {
-	PlatformClient  *platform.ClientWithResponses
+	PlatformClient  platform.ClientWithResponsesInterface
 	OrganizationId  string
 	DeploymentRoles []iam.DeploymentRole
 	WorkspaceRoles  []iam.WorkspaceRole
@@ -133,25 +133,44 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 	})
 	deploymentRoleIds = lo.Uniq(deploymentRoleIds)
 
-	// get list of deployments
-	listDeployments, err := input.PlatformClient.ListDeploymentsWithResponse(ctx, input.OrganizationId, &platform.ListDeploymentsParams{
+	// get list of deployments (paginated)
+	params := &platform.ListDeploymentsParams{
 		DeploymentIds: &deploymentRoleIds,
-	})
-	if err != nil {
-		tflog.Error(ctx, "failed to mutate roles", map[string]interface{}{"error": err})
-		return diag.Diagnostics{diag.NewErrorDiagnostic(
-			"Client Error",
-			fmt.Sprintf("Unable to mutate roles and list deployments, got error: %s", err),
-		),
-		}
+		Limit:         lo.ToPtr(100),
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, listDeployments.HTTPResponse, listDeployments.Body)
-	if diagnostic != nil {
-		return diag.Diagnostics{diagnostic}
+
+	var queriedDeployments []platform.Deployment
+	offset := 0 // Will be incremented appropriately to ensure all Deployments are returned
+
+	for {
+		params.Offset = &offset
+		listDeployments, err := input.PlatformClient.ListDeploymentsWithResponse(ctx, input.OrganizationId, params)
+
+		if err != nil {
+			tflog.Error(ctx, "failed to mutate roles", map[string]interface{}{"error": err})
+			return diag.Diagnostics{diag.NewErrorDiagnostic(
+				"Client Error",
+				fmt.Sprintf("Unable to mutate roles and list deployments, got error: %s", err),
+			)}
+		}
+
+		_, diagnostic := clients.NormalizeAPIError(ctx, listDeployments.HTTPResponse, listDeployments.Body)
+		if diagnostic != nil {
+			return diag.Diagnostics{diagnostic}
+		}
+
+		// Append new Deployments to queriedDeployments, which we'll eventually use to validate Deployment ID's
+		queriedDeployments = append(queriedDeployments, listDeployments.JSON200.Deployments...)
+
+		// Break if we've hit the last page; otherwise, increment the offset and continue
+		if listDeployments.JSON200.TotalCount <= offset+len(listDeployments.JSON200.Deployments) {
+			break
+		}
+		offset += 100
 	}
 
 	// get list of deployment ids
-	deploymentIds := lo.Map(listDeployments.JSON200.Deployments, func(deployment platform.Deployment, _ int) string {
+	deploymentIds := lo.Map(queriedDeployments, func(deployment platform.Deployment, _ int) string {
 		return deployment.Id
 	})
 
@@ -167,7 +186,7 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 	}
 
 	// get list of workspace ids from deployments
-	deploymentWorkspaceIds := lo.Map(listDeployments.JSON200.Deployments, func(deployment platform.Deployment, _ int) string {
+	deploymentWorkspaceIds := lo.Map(queriedDeployments, func(deployment platform.Deployment, _ int) string {
 		return deployment.WorkspaceId
 	})
 	deploymentWorkspaceIds = lo.Uniq(deploymentWorkspaceIds)

--- a/internal/provider/common/role.go
+++ b/internal/provider/common/role.go
@@ -154,6 +154,16 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 			)}
 		}
 
+		if listDeployments.JSON200 == nil {
+			return diag.Diagnostics{diag.NewErrorDiagnostic(
+				"Client Error", "Unable to list deployments, got nil response")}
+		}
+
+		// Handle an empty page, breaking early
+		if len(listDeployments.JSON200.Deployments) == 0 {
+			break
+		}
+
 		_, diagnostic := clients.NormalizeAPIError(ctx, listDeployments.HTTPResponse, listDeployments.Body)
 		if diagnostic != nil {
 			return diag.Diagnostics{diagnostic}
@@ -166,7 +176,7 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 		if listDeployments.JSON200.TotalCount <= offset+len(listDeployments.JSON200.Deployments) {
 			break
 		}
-		offset += 100
+		offset += len(listDeployments.JSON200.Deployments)
 	}
 
 	// get list of deployment ids

--- a/internal/provider/common/role_test.go
+++ b/internal/provider/common/role_test.go
@@ -275,4 +275,149 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		assert.False(t, diags.HasError())
 		mockClient.AssertNumberOfCalls(t, "ListDeploymentsWithResponse", 2)
 	})
+
+	t.Run("client error on second page is returned as diagnostic", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+
+		page1Deps := make([]platform.Deployment, 100)
+		for i := range page1Deps {
+			page1Deps[i] = platform.Deployment{Id: fmt.Sprintf("dep-%d", i), WorkspaceId: workspaceId}
+		}
+
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.MatchedBy(func(p *platform.ListDeploymentsParams) bool {
+			return p.Offset != nil && *p.Offset == 0
+		})).Return(makeDeploymentsPaginatedResponse(page1Deps, 150), nil).Once()
+
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.MatchedBy(func(p *platform.ListDeploymentsParams) bool {
+			return p.Offset != nil && *p.Offset == 100
+		})).Return(nil, fmt.Errorf("timeout on page 2")).Once()
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-149", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.True(t, diags.HasError())
+		assert.Contains(t, diags[0].Detail(), "timeout on page 2")
+	})
+
+	t.Run("nil JSON200 in response is returned as diagnostic", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		nilBodyResp := &platform.ListDeploymentsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200:      nil,
+		}
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(nilBodyResp, nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.True(t, diags.HasError())
+	})
+
+	t.Run("deployments across multiple workspaces with all workspace roles covered returns no diagnostics", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		deps := []platform.Deployment{
+			{Id: "dep-1", WorkspaceId: "ws-1"},
+			{Id: "dep-2", WorkspaceId: "ws-2"},
+		}
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(makeDeploymentsPaginatedResponse(deps, 2), nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient: mockClient,
+			OrganizationId: orgId,
+			DeploymentRoles: []iam.DeploymentRole{
+				{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"},
+				{DeploymentId: "dep-2", Role: "DEPLOYMENT_ADMIN"},
+			},
+			WorkspaceRoles: []iam.WorkspaceRole{
+				{WorkspaceId: "ws-1", Role: iam.WORKSPACEOWNER},
+				{WorkspaceId: "ws-2", Role: iam.WORKSPACEMEMBER},
+			},
+		})
+		assert.False(t, diags.HasError())
+	})
+
+	t.Run("deployments across multiple workspaces with only partial workspace roles is reported as diagnostic", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		deps := []platform.Deployment{
+			{Id: "dep-1", WorkspaceId: "ws-1"},
+			{Id: "dep-2", WorkspaceId: "ws-2"},
+		}
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(makeDeploymentsPaginatedResponse(deps, 2), nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient: mockClient,
+			OrganizationId: orgId,
+			DeploymentRoles: []iam.DeploymentRole{
+				{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"},
+				{DeploymentId: "dep-2", Role: "DEPLOYMENT_ADMIN"},
+			},
+			// ws-2 is missing a workspace role
+			WorkspaceRoles: []iam.WorkspaceRole{
+				{WorkspaceId: "ws-1", Role: iam.WORKSPACEOWNER},
+			},
+		})
+		assert.True(t, diags.HasError())
+	})
+
+	t.Run("duplicate deployment IDs are deduplicated before validation", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		dep := platform.Deployment{Id: "dep-1", WorkspaceId: workspaceId}
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(makeDeploymentsPaginatedResponse([]platform.Deployment{dep}, 1), nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient: mockClient,
+			OrganizationId: orgId,
+			// same deployment ID provided twice
+			DeploymentRoles: []iam.DeploymentRole{
+				{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"},
+				{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"},
+			},
+			WorkspaceRoles: []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.False(t, diags.HasError())
+	})
+
+	t.Run("pagination offset advances by actual page size for partial last page", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+
+		// Page 1: only 75 results (less than the 100 limit), totalCount=125
+		page1Deps := make([]platform.Deployment, 75)
+		for i := range page1Deps {
+			page1Deps[i] = platform.Deployment{Id: fmt.Sprintf("dep-%d", i), WorkspaceId: workspaceId}
+		}
+		// Page 2: 50 remaining results starting at offset 75
+		page2Deps := make([]platform.Deployment, 50)
+		for i := range page2Deps {
+			page2Deps[i] = platform.Deployment{Id: fmt.Sprintf("dep-%d", i+75), WorkspaceId: workspaceId}
+		}
+
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.MatchedBy(func(p *platform.ListDeploymentsParams) bool {
+			return p.Offset != nil && *p.Offset == 0
+		})).Return(makeDeploymentsPaginatedResponse(page1Deps, 125), nil).Once()
+
+		// Offset must be 75 (len of page 1), not 100 (fixed limit)
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.MatchedBy(func(p *platform.ListDeploymentsParams) bool {
+			return p.Offset != nil && *p.Offset == 75
+		})).Return(makeDeploymentsPaginatedResponse(page2Deps, 125), nil).Once()
+
+		// dep-124 only appears on page 2
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-124", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.False(t, diags.HasError())
+		mockClient.AssertNumberOfCalls(t, "ListDeploymentsWithResponse", 2)
+	})
 }

--- a/internal/provider/common/role_test.go
+++ b/internal/provider/common/role_test.go
@@ -1,10 +1,17 @@
 package common_test
 
 import (
+	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
+	"github.com/astronomer/terraform-provider-astro/internal/clients/platform"
+	mocks_platform "github.com/astronomer/terraform-provider-astro/internal/mocks/platform"
 	"github.com/astronomer/terraform-provider-astro/internal/provider/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestValidateRoleMatchesEntityType(t *testing.T) {
@@ -127,4 +134,145 @@ func TestValidateRoleMatchesEntityType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeDeploymentsPaginatedResponse(deployments []platform.Deployment, totalCount int) *platform.ListDeploymentsResponse {
+	return &platform.ListDeploymentsResponse{
+		HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+		JSON200: &platform.DeploymentsPaginated{
+			Deployments: deployments,
+			TotalCount:  totalCount,
+		},
+	}
+}
+
+func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
+	ctx := context.Background()
+	orgId := "org-1"
+	workspaceId := "ws-1"
+
+	t.Run("no deployment roles returns nil diagnostics", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{},
+			WorkspaceRoles:  []iam.WorkspaceRole{},
+		})
+		assert.Nil(t, diags)
+		mockClient.AssertNotCalled(t, "ListDeploymentsWithResponse")
+	})
+
+	t.Run("client error is returned as diagnostic", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(nil, fmt.Errorf("connection refused"))
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.True(t, diags.HasError())
+		assert.Contains(t, diags[0].Detail(), "connection refused")
+	})
+
+	t.Run("non-200 API response is returned as diagnostic", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		errResp := &platform.ListDeploymentsResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusInternalServerError},
+			Body:         []byte(`{"message":"internal error"}`),
+		}
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(errResp, nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.True(t, diags.HasError())
+	})
+
+	t.Run("invalid deployment ID is reported as diagnostic", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		// API returns no deployments matching the requested ID
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(makeDeploymentsPaginatedResponse([]platform.Deployment{}, 0), nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-nonexistent", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.True(t, diags.HasError())
+		assert.Contains(t, diags[0].Detail(), "dep-nonexistent")
+	})
+
+	t.Run("missing workspace role for deployment's workspace is reported as diagnostic", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		dep := platform.Deployment{Id: "dep-1", WorkspaceId: "ws-other"}
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(makeDeploymentsPaginatedResponse([]platform.Deployment{dep}, 1), nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
+			// workspace role is for a different workspace than the deployment belongs to
+			WorkspaceRoles: []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.True(t, diags.HasError())
+	})
+
+	t.Run("valid single-page result returns no diagnostics", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+		dep := platform.Deployment{Id: "dep-1", WorkspaceId: workspaceId}
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.Anything).
+			Return(makeDeploymentsPaginatedResponse([]platform.Deployment{dep}, 1), nil)
+
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.False(t, diags.HasError())
+	})
+
+	t.Run("paginated results are accumulated across multiple pages", func(t *testing.T) {
+		mockClient := new(mocks_platform.ClientWithResponsesInterface)
+
+		// Page 1: returns 100 deployments, totalCount=150 signals a second page is needed
+		page1Deps := make([]platform.Deployment, 100)
+		for i := range page1Deps {
+			page1Deps[i] = platform.Deployment{Id: fmt.Sprintf("dep-%d", i), WorkspaceId: workspaceId}
+		}
+		// Page 2: the remaining 50 deployments, including the one referenced in DeploymentRoles
+		page2Deps := make([]platform.Deployment, 50)
+		for i := range page2Deps {
+			page2Deps[i] = platform.Deployment{Id: fmt.Sprintf("dep-%d", i+100), WorkspaceId: workspaceId}
+		}
+
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.MatchedBy(func(p *platform.ListDeploymentsParams) bool {
+			return p.Offset != nil && *p.Offset == 0
+		})).Return(makeDeploymentsPaginatedResponse(page1Deps, 150), nil).Once()
+
+		mockClient.On("ListDeploymentsWithResponse", ctx, orgId, mock.MatchedBy(func(p *platform.ListDeploymentsParams) bool {
+			return p.Offset != nil && *p.Offset == 100
+		})).Return(makeDeploymentsPaginatedResponse(page2Deps, 150), nil).Once()
+
+		// dep-149 only appears on page 2 — this validates pagination is working
+		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
+			PlatformClient:  mockClient,
+			OrganizationId:  orgId,
+			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-149", Role: "DEPLOYMENT_ADMIN"}},
+			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
+		})
+		assert.False(t, diags.HasError())
+		mockClient.AssertNumberOfCalls(t, "ListDeploymentsWithResponse", 2)
+	})
 }

--- a/internal/provider/common/role_test.go
+++ b/internal/provider/common/role_test.go
@@ -156,6 +156,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{},
 			WorkspaceRoles:  []iam.WorkspaceRole{},
 		})
@@ -171,6 +172,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})
@@ -190,6 +192,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})
@@ -205,6 +208,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-nonexistent", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})
@@ -221,6 +225,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
 			// workspace role is for a different workspace than the deployment belongs to
 			WorkspaceRoles: []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
@@ -237,6 +242,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})
@@ -269,6 +275,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-149", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})
@@ -295,6 +302,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-149", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})
@@ -314,6 +322,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})
@@ -332,6 +341,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient: mockClient,
 			OrganizationId: orgId,
+			Limit:          100,
 			DeploymentRoles: []iam.DeploymentRole{
 				{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"},
 				{DeploymentId: "dep-2", Role: "DEPLOYMENT_ADMIN"},
@@ -356,6 +366,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient: mockClient,
 			OrganizationId: orgId,
+			Limit:          100,
 			DeploymentRoles: []iam.DeploymentRole{
 				{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"},
 				{DeploymentId: "dep-2", Role: "DEPLOYMENT_ADMIN"},
@@ -377,6 +388,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient: mockClient,
 			OrganizationId: orgId,
+			Limit:          100,
 			// same deployment ID provided twice
 			DeploymentRoles: []iam.DeploymentRole{
 				{DeploymentId: "dep-1", Role: "DEPLOYMENT_ADMIN"},
@@ -414,6 +426,7 @@ func TestValidateWorkspaceDeploymentRoles(t *testing.T) {
 		diags := common.ValidateWorkspaceDeploymentRoles(ctx, common.ValidateWorkspaceDeploymentRolesInput{
 			PlatformClient:  mockClient,
 			OrganizationId:  orgId,
+			Limit:           100,
 			DeploymentRoles: []iam.DeploymentRole{{DeploymentId: "dep-124", Role: "DEPLOYMENT_ADMIN"}},
 			WorkspaceRoles:  []iam.WorkspaceRole{{WorkspaceId: workspaceId, Role: iam.WORKSPACEOWNER}},
 		})


### PR DESCRIPTION
…when upserting `team_roles`

## Description

When attempting to mutate a team with more than 20 Deployments, applying `astro_team_roles` changes fails with `"Unable to mutate roles, not every deployment role has a corresponding valid Deployment"` even though the referenced Deployments exist.

This was due to the default `limit=20` set in the Astro API (https://www.astronomer.io/docs/astro/api/v-1/api-reference/deployment/list-deployments#request.query.limit). When more than 20 Deployments are passed in (which is a very valid pattern, as a team may have more than 20 Deployments it should have access to) the `GET` only returned the first 20.

This PR introduces a fix for this, where Deployments are paginated over until all Deployments have been returned. **Unit tests were also added as a part of this PR.**

## 🎟 Issue(s)

https://linear.app/astronomer/issue/CPP-731/terraform-provider-fails-when-workspace-has-over-20-deployments

## 🧪 Functional Testing

The following function testing was done to validate this change. The screenshots showing this successful testing is include below.

* Create a new team called `paginate-list-deployments Team`.
* Create a Workspace.
* Create 25 Deployments.
* Assign a team role to the `paginate-list-deployments Team` with 25 Deployments.

## 📸 Screenshots

Team was successfully created with roles assignments for 25 Deployments.

<img width="1001" height="811" alt="image" src="https://github.com/user-attachments/assets/b35ea55a-0d33-41a3-bade-c769215b7975" />


## 📋 Checklist

- [X] Added/updated applicable tests
- [X] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
