### PR TITLE
Fix Extra Object Attribute error for DAG_TRIGGER notification channels

### DIFF
--- a/internal/provider/models/notification_channel.go
+++ b/internal/provider/models/notification_channel.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/astronomer/terraform-provider-astro/internal/clients/platform"
 	"github.com/astronomer/terraform-provider-astro/internal/provider/schemas"
@@ -145,6 +144,9 @@ func (data *NotificationChannelResource) ReadFromResponse(ctx context.Context, n
 }
 
 // NotificationChannelDefinitionDataSourceTypesObject converts a generic interface{} to a Terraform types.Object
+// matching the data source schema. The Astro API returns camelCase keys (e.g. dagId, deploymentId) which must be
+// mapped to the snake_case attribute names declared in the Terraform schema before constructing the Object —
+// otherwise types.ObjectValue rejects the extra keys with "Extra Object Attribute Name: <key>".
 func NotificationChannelDefinitionDataSourceTypesObject(ctx context.Context, def interface{}) (types.Object, diag.Diagnostics) {
 	// Cast to map[string]interface{} or default empty
 	var defMap map[string]interface{}
@@ -165,36 +167,55 @@ func NotificationChannelDefinitionDataSourceTypesObject(ctx context.Context, def
 		"webhook_url":          types.StringNull(),
 	}
 
-	// Override with actual values when present
-	for k, v := range defMap {
-		switch val := v.(type) {
-		case string:
-			if val != "" {
-				defAttrMap[k] = types.StringValue(val)
-			}
-		case []interface{}:
-			// Handle array values (like recipients)
-			var stringValues []attr.Value
-			for _, item := range val {
-				if str, ok := item.(string); ok && str != "" {
-					stringValues = append(stringValues, types.StringValue(str))
-				}
-			}
-			if len(stringValues) > 0 {
-				set, diags := types.SetValue(types.StringType, stringValues)
-				if diags.HasError() {
-					return types.Object{}, diags
-				}
-				defAttrMap[k] = set
-			}
-		default:
-			if v != nil {
-				defAttrMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+	// Map every camelCase key the OpenAPI spec declares for a NotificationChannelDefinition to its snake_case
+	// schema attribute. Sensitive fields (deploymentApiToken, apiKey, integrationKey, webhookUrl) are typically
+	// stripped by the API for security, but we handle them defensively in case the backend ever returns them.
+
+	// String fields: camelCase API key → snake_case schema attr
+	stringKeyMap := map[string]string{
+		"dagId":              "dag_id",
+		"deploymentApiToken": "deployment_api_token",
+		"deploymentId":       "deployment_id",
+		"apiKey":             "api_key",
+		"integrationKey":     "integration_key",
+		"webhookUrl":         "webhook_url",
+	}
+	for apiKey, attrKey := range stringKeyMap {
+		if v, ok := defMap[apiKey]; ok && v != nil {
+			if s, ok := v.(string); ok && s != "" {
+				defAttrMap[attrKey] = types.StringValue(s)
 			}
 		}
 	}
 
-	// Create Terraform object using the definition attribute types
+	// Handle recipients (set of strings, used by EMAIL channels)
+	if v, ok := defMap["recipients"]; ok && v != nil {
+		if arr, ok := v.([]interface{}); ok {
+			recipientVals := make([]attr.Value, 0, len(arr))
+			for _, el := range arr {
+				if s, ok2 := el.(string); ok2 {
+					recipientVals = append(recipientVals, types.StringValue(s))
+				}
+			}
+			if len(recipientVals) > 0 {
+				defAttrMap["recipients"] = types.SetValueMust(types.StringType, recipientVals)
+			} else {
+				defAttrMap["recipients"] = types.SetValueMust(types.StringType, []attr.Value{})
+			}
+		}
+	}
+
+	// Surface unrecognized keys at Debug level so future API additions are visible without breaking apply.
+	for k := range defMap {
+		if _, known := stringKeyMap[k]; known {
+			continue
+		}
+		if k == "recipients" {
+			continue
+		}
+		tflog.Warn(ctx, "Ignoring unrecognized notification channel definition key from API", map[string]interface{}{"key": k})
+	}
+
 	return types.ObjectValue(schemas.NotificationChannelDefinitionAttributeTypes(), defAttrMap)
 }
 

--- a/internal/provider/models/notification_channel.go
+++ b/internal/provider/models/notification_channel.go
@@ -205,7 +205,7 @@ func NotificationChannelDefinitionDataSourceTypesObject(ctx context.Context, def
 		}
 	}
 
-	// Surface unrecognized keys at Debug level so future API additions are visible without breaking apply.
+	// Surface unrecognized keys at Warn level so future API additions are visible without breaking apply.
 	for k := range defMap {
 		if _, known := stringKeyMap[k]; known {
 			continue

--- a/internal/provider/models/notification_channel.go
+++ b/internal/provider/models/notification_channel.go
@@ -216,7 +216,11 @@ func NotificationChannelDefinitionDataSourceTypesObject(ctx context.Context, def
 		tflog.Warn(ctx, "Ignoring unrecognized notification channel definition key from API", map[string]interface{}{"key": k})
 	}
 
-	return types.ObjectValue(schemas.NotificationChannelDefinitionAttributeTypes(), defAttrMap)
+	obj, objDiags := types.ObjectValue(schemas.NotificationChannelDefinitionAttributeTypes(), defAttrMap)
+	if objDiags.HasError() {
+		return types.Object{}, objDiags
+	}
+	return obj, nil
 }
 
 // NotificationChannelDefinitionResourceTypesObject maps platform notification channel definitions into a Terraform types.Object matching the resource schema.

--- a/internal/provider/models/notification_channel_test.go
+++ b/internal/provider/models/notification_channel_test.go
@@ -1,0 +1,166 @@
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
+)
+
+// TestUnit_NotificationChannelDefinitionDataSourceTypesObject is the regression guard for CPP-737.
+// Before the fix, a notification channel definition coming back from the API with camelCase keys
+// (dagId, deploymentId, etc.) caused types.ObjectValue to reject the extra attributes
+// ("Extra Object Attribute Name: dagId"), breaking any astro_alert that referenced such a channel.
+//
+// The cases cover every channel type the OpenAPI spec declares (per platform.api.gen.go):
+//   - DAG_TRIGGER: dagId, deploymentApiToken, deploymentId
+//   - EMAIL: recipients
+//   - OPSGENIE: apiKey
+//   - PAGERDUTY: integrationKey
+//   - SLACK: webhookUrl
+func TestUnit_NotificationChannelDefinitionDataSourceTypesObject(t *testing.T) {
+	tests := []struct {
+		name      string
+		def       interface{}
+		expectErr bool
+		// expected snake_case attribute values; empty string means expect-null
+		wantStrings    map[string]string
+		wantRecipients []string // nil means expect-null
+	}{
+		{
+			name: "DAG_TRIGGER with dagId, deploymentId, and deploymentApiToken",
+			def: map[string]interface{}{
+				"dagId":              "test_dag",
+				"deploymentId":       "clxxxxxxxxxxxxxxxxxxxx",
+				"deploymentApiToken": "tok_secret",
+			},
+			wantStrings: map[string]string{
+				"dag_id":               "test_dag",
+				"deployment_id":        "clxxxxxxxxxxxxxxxxxxxx",
+				"deployment_api_token": "tok_secret",
+			},
+		},
+		{
+			name: "DAG_TRIGGER without deploymentApiToken (typical API response with sensitive field stripped)",
+			def: map[string]interface{}{
+				"dagId":        "test_dag",
+				"deploymentId": "clxxxxxxxxxxxxxxxxxxxx",
+			},
+			wantStrings: map[string]string{
+				"dag_id":        "test_dag",
+				"deployment_id": "clxxxxxxxxxxxxxxxxxxxx",
+			},
+		},
+		{
+			name: "EMAIL with recipients",
+			def: map[string]interface{}{
+				"recipients": []interface{}{"a@example.com", "b@example.com"},
+			},
+			wantRecipients: []string{"a@example.com", "b@example.com"},
+		},
+		{
+			// API response with an explicit empty recipients array — distinct from absent recipients key.
+			// The decoder produces an empty non-null set here. Plain absence would produce a null set;
+			// the difference is visible in Terraform plan diffs and matters for permadiff prevention.
+			name: "EMAIL with empty recipients array",
+			def: map[string]interface{}{
+				"recipients": []interface{}{},
+			},
+			wantRecipients: []string{},
+		},
+		{
+			name: "OPSGENIE with apiKey",
+			def: map[string]interface{}{
+				"apiKey": "ops_key",
+			},
+			wantStrings: map[string]string{"api_key": "ops_key"},
+		},
+		{
+			name: "PAGERDUTY with integrationKey",
+			def: map[string]interface{}{
+				"integrationKey": "pd_int_key",
+			},
+			wantStrings: map[string]string{"integration_key": "pd_int_key"},
+		},
+		{
+			name: "SLACK with webhookUrl",
+			def: map[string]interface{}{
+				"webhookUrl": "https://hooks.slack.com/services/x/y/z",
+			},
+			wantStrings: map[string]string{"webhook_url": "https://hooks.slack.com/services/x/y/z"},
+		},
+		{
+			name: "extra unknown camelCase key is ignored, not raised as a diag",
+			def: map[string]interface{}{
+				"dagId":           "test_dag",
+				"deploymentId":    "clxxxxxxxxxxxxxxxxxxxx",
+				"someFutureField": "ignored",
+			},
+			wantStrings: map[string]string{
+				"dag_id":        "test_dag",
+				"deployment_id": "clxxxxxxxxxxxxxxxxxxxx",
+			},
+		},
+		{
+			name: "nil definition produces null attrs without error",
+			def:  nil,
+		},
+		{
+			name: "empty definition produces null attrs without error",
+			def:  map[string]interface{}{},
+		},
+	}
+
+	allStringAttrs := []string{
+		"dag_id", "deployment_api_token", "deployment_id",
+		"api_key", "integration_key", "webhook_url",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, diags := models.NotificationChannelDefinitionDataSourceTypesObject(context.Background(), tc.def)
+			if tc.expectErr {
+				assert.True(t, diags.HasError(), "expected diags to have an error")
+				return
+			}
+			assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
+			// Named regression guard for CPP-737: the original failure surfaced as an
+			// "Extra Object Attribute Name: <key>" diagnostic from types.ObjectValue when
+			// raw camelCase API keys leaked into a schema-keyed attr map.
+			for _, d := range diags {
+				assert.NotContains(t, d.Detail(), "Extra Object Attribute Name",
+					"CPP-737 regression: unexpected schema attribute mismatch")
+				assert.NotContains(t, d.Summary(), "Extra Object Attribute Name",
+					"CPP-737 regression: unexpected schema attribute mismatch")
+			}
+
+			attrs := obj.Attributes()
+
+			for _, k := range allStringAttrs {
+				s, _ := attrs[k].(types.String)
+				if want, ok := tc.wantStrings[k]; ok {
+					assert.Equal(t, want, s.ValueString(), "attribute %s", k)
+				} else {
+					assert.True(t, s.IsNull(), "expected %s to be null", k)
+				}
+			}
+
+			recipients, _ := attrs["recipients"].(types.Set)
+			if tc.wantRecipients == nil {
+				assert.True(t, recipients.IsNull(), "expected recipients to be null")
+			} else {
+				assert.False(t, recipients.IsNull(), "expected recipients to be a non-null set")
+				elems := recipients.Elements()
+				got := make([]string, 0, len(elems))
+				for _, e := range elems {
+					s, _ := e.(types.String)
+					got = append(got, s.ValueString())
+				}
+				assert.ElementsMatch(t, tc.wantRecipients, got)
+			}
+		})
+	}
+}

--- a/internal/provider/models/notification_channel_test.go
+++ b/internal/provider/models/notification_channel_test.go
@@ -23,9 +23,8 @@ import (
 //   - SLACK: webhookUrl
 func TestUnit_NotificationChannelDefinitionDataSourceTypesObject(t *testing.T) {
 	tests := []struct {
-		name      string
-		def       interface{}
-		expectErr bool
+		name string
+		def  interface{}
 		// expected snake_case attribute values; empty string means expect-null
 		wantStrings    map[string]string
 		wantRecipients []string // nil means expect-null
@@ -93,6 +92,19 @@ func TestUnit_NotificationChannelDefinitionDataSourceTypesObject(t *testing.T) {
 			wantStrings: map[string]string{"webhook_url": "https://hooks.slack.com/services/x/y/z"},
 		},
 		{
+			// A known camelCase key with an empty-string value is treated as null,
+			// not as a known-empty-string. This matters for Terraform plan diffs.
+			name: "empty-string value on a known key maps to null",
+			def: map[string]interface{}{
+				"dagId":        "",
+				"deploymentId": "clxxxxxxxxxxxxxxxxxxxx",
+			},
+			wantStrings: map[string]string{
+				// dag_id intentionally omitted — empty string yields null
+				"deployment_id": "clxxxxxxxxxxxxxxxxxxxx",
+			},
+		},
+		{
 			name: "extra unknown camelCase key is ignored, not raised as a diag",
 			def: map[string]interface{}{
 				"dagId":           "test_dag",
@@ -122,10 +134,6 @@ func TestUnit_NotificationChannelDefinitionDataSourceTypesObject(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			obj, diags := models.NotificationChannelDefinitionDataSourceTypesObject(context.Background(), tc.def)
-			if tc.expectErr {
-				assert.True(t, diags.HasError(), "expected diags to have an error")
-				return
-			}
 			assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
 			// Named regression guard for issue #313: the original failure surfaced as an
 			// "Extra Object Attribute Name: <key>" diagnostic from types.ObjectValue when

--- a/internal/provider/models/notification_channel_test.go
+++ b/internal/provider/models/notification_channel_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
 )
 
-// TestUnit_NotificationChannelDefinitionDataSourceTypesObject is the regression guard for CPP-737.
+// TestUnit_NotificationChannelDefinitionDataSourceTypesObject is the regression guard for issue #313.
 // Before the fix, a notification channel definition coming back from the API with camelCase keys
 // (dagId, deploymentId, etc.) caused types.ObjectValue to reject the extra attributes
 // ("Extra Object Attribute Name: dagId"), breaking any astro_alert that referenced such a channel.
@@ -127,14 +127,14 @@ func TestUnit_NotificationChannelDefinitionDataSourceTypesObject(t *testing.T) {
 				return
 			}
 			assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
-			// Named regression guard for CPP-737: the original failure surfaced as an
+			// Named regression guard for issue #313: the original failure surfaced as an
 			// "Extra Object Attribute Name: <key>" diagnostic from types.ObjectValue when
 			// raw camelCase API keys leaked into a schema-keyed attr map.
 			for _, d := range diags {
 				assert.NotContains(t, d.Detail(), "Extra Object Attribute Name",
-					"CPP-737 regression: unexpected schema attribute mismatch")
+					"regression for issue #313: unexpected schema attribute mismatch")
 				assert.NotContains(t, d.Summary(), "Extra Object Attribute Name",
-					"CPP-737 regression: unexpected schema attribute mismatch")
+					"regression for issue #313: unexpected schema attribute mismatch")
 			}
 
 			attrs := obj.Attributes()


### PR DESCRIPTION
## Description

`astro_alert` resources of type `DAG_DURATION` that reference a `DAG_TRIGGER` notification channel were failing during `terraform apply` / `refresh` with:

```
Extra Object Attribute Name: dagId
Extra Object Attribute Name: deploymentId
```

Root cause: the data-source decoder for notification channel definitions (`NotificationChannelDefinitionDataSourceTypesObject` in `internal/provider/models/notification_channel.go`) was iterating the raw API response map and writing camelCase keys (`dagId`, `deploymentId`) directly into a schema-keyed `attr.Value` map. `types.ObjectValue` then rejected the extra keys because the Terraform schema declares snake_case attribute names. The sibling **resource** decoder (`NotificationChannelDefinitionResourceTypesObject` in the same file) already handled this correctly with explicit camelCase to snake_case mapping — the data-source twin was the only broken site.

Fix: replace the unsafe loop with an explicit camelCase to snake_case mapping covering all seven fields the OpenAPI spec declares for a notification channel definition (`dagId`, `deploymentApiToken`, `deploymentId`, `apiKey`, `integrationKey`, `webhookUrl`, plus `recipients` as a set). Sensitive fields are handled defensively even though the backend typically strips them. Unrecognized future keys log at `Warn` so API drift surfaces in operator logs without breaking apply.

## 🎟 Issue(s)

Closes #313

## 🧪 Functional Testing

### Unit tests

```
go test ./internal/provider/models/... -run TestUnit -v
```

All 10 subtests PASS: DAG_TRIGGER with/without the sensitive token, EMAIL, EMAIL with empty recipients array, OPSGENIE, PAGERDUTY, SLACK, unknown camelCase key, nil input, empty map. The test asserts that no diagnostic contains `Extra Object Attribute Name` as a named regression guard for #313.

### Build / vet

- `go vet ./...` — clean
- `go build ./...` — clean

### Local end-to-end verification

Two test directories, same Terraform config, different provider builds:

- **Buggy baseline:** `tpa-buggy` checked out at `origin/main` (`366d28e`)
- **Fix candidate:** this branch (`ef5c204`)

The config creates an `astro_deployment` + `astro_api_token` + `astro_notification_channel` (DAG_TRIGGER) + `astro_alert` (DAG_DURATION) referencing the channel — the exact configuration in #313's repro.

| Scenario | Provider build | Outcome |
|---|---|---|
| DAG_DURATION alert + DAG_TRIGGER channel | tpa-buggy (`main`, 366d28e) | **FAIL** during `astro_alert` creation with two diagnostics:<br>`Error: Extra Object Attribute Value … Extra Object Attribute Name: dagId`<br>`Error: Extra Object Attribute Value … Extra Object Attribute Name: deploymentId`<br>Both errors fire because the buggy loop writes both raw camelCase keys into the schema-keyed map. |
| Same config | This fix (`ef5c204`) | **PASS** — `Apply complete! Resources: 4 added, 0 changed, 0 destroyed.` Second `terraform plan` returns `No changes. Your infrastructure matches the configuration.` (idempotent.) |


## 📸 Screenshots

N/A — provider runtime fix, no UI or CLI surface change. The local-test output is captured verbatim in the table above.

## 📋 Checklist

- [x] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory — N/A (no new resource fields or behavior visible in HCL)
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/) — N/A (no user-facing surface change; bug fix to existing decode path)

## Notes for reviewers

- The 7-key mapping is verified against `internal/clients/platform/api.gen.go`: 5 channel-definition structs declare exactly the 7 JSON keys handled here. No phantom entries, no missing entries.