### PR TITLE
feat!: astro_users users is now a List instead of a Set (BREAKING) + stable id sort

### DIFF
--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -39,7 +39,7 @@ output "example_users" {
 
 ### Read-Only
 
-- `users` (Attributes Set) (see [below for nested schema](#nestedatt--users))
+- `users` (Attributes List) (see [below for nested schema](#nestedatt--users))
 
 <a id="nestedatt--users"></a>
 ### Nested Schema for `users`

--- a/internal/provider/datasources/data_source_users.go
+++ b/internal/provider/datasources/data_source_users.go
@@ -85,6 +85,11 @@ func (d *usersDataSource) Read(
 
 	params := &iam.ListUsersParams{
 		Limit: lo.ToPtr(1000),
+		// Sort by id (immutable, unique) so pagination is stable across calls and
+		// the resulting list ordering is deterministic between plans. Without this,
+		// the API's default ordering can shift between reads, producing spurious
+		// plan diffs now that `users` is an ordered List instead of a Set.
+		Sorts: &[]iam.ListUsersParamsSorts{iam.ListUsersParamsSortsIdAsc},
 	}
 	var diags diag.Diagnostics
 	workspaceId := data.WorkspaceId.ValueString()

--- a/internal/provider/models/users.go
+++ b/internal/provider/models/users.go
@@ -12,7 +12,7 @@ import (
 
 // Users describes the data source data model.
 type Users struct {
-	Users        types.Set    `tfsdk:"users"`
+	Users        types.List   `tfsdk:"users"`
 	WorkspaceId  types.String `tfsdk:"workspace_id"`  // query parameter
 	DeploymentId types.String `tfsdk:"deployment_id"` // query parameter
 }
@@ -33,7 +33,7 @@ func (data *Users) ReadFromResponse(ctx context.Context, users []iam.User) diag.
 		values[i] = objectValue
 	}
 	var diags diag.Diagnostics
-	data.Users, diags = types.SetValue(types.ObjectType{AttrTypes: schemas.UsersElementAttributeTypes()}, values)
+	data.Users, diags = types.ListValue(types.ObjectType{AttrTypes: schemas.UsersElementAttributeTypes()}, values)
 	if diags.HasError() {
 		return diags
 	}

--- a/internal/provider/schemas/users.go
+++ b/internal/provider/schemas/users.go
@@ -38,7 +38,7 @@ func UsersElementAttributeTypes() map[string]attr.Type {
 
 func UsersDataSourceSchemaAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		"users": schema.SetNestedAttribute{
+		"users": schema.ListNestedAttribute{
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: UserDataSourceSchemaAttributes(),
 			},


### PR DESCRIPTION
## Description

> [!WARNING]
> **BREAKING CHANGE — requires a major version bump (v2.0.0).** This must not ship in a patch/minor release. Per `CONTRIBUTING.md`, major versions are reserved for breaking changes that require user action. **Hold for the next major release.**

This PR builds on #317 (`fix: improve astro_users performance by using list instead of set`) and adds an explicit `id:asc` sort to the `astro_users` data source's `ListUsers` call. It includes the commit from #317 plus one additional change so the two ship together.

### ⚠️ Breaking change

The `astro_users` data source's `users` attribute changes from a nested **Set** (`SetNestedAttribute` / `types.Set`) to a nested **List** (`ListNestedAttribute` / `types.List`).

`data.astro_users.<name>.users` is a public read-only attribute, so this changes the schema contract consumers depend on:

- **`for_each` no longer accepts the attribute directly** — `for_each` requires a set or map, not a list. Configs must update:
  ```hcl
  # Before
  for_each = data.astro_users.example.users

  # After
  for_each = { for u in data.astro_users.example.users : u.id => u }
  # or
  for_each = toset([for u in data.astro_users.example.users : u.id])
  ```
- **Set functions** (`setunion`, `setsubtract`, `setintersection`) applied to `users` now need a `toset(...)` coercion.
- **Ordering semantics change** from unordered (set) to positional (list). The `id:asc` sort below keeps that ordering deterministic so it doesn't cause spurious plan diffs.

### Why the change

#317 changes `users` from a nested Set to a nested List. A List is **ordered**, so the order the IAM API returns users in becomes load-bearing:

1. **Spurious plan diffs** — if the API's default ordering shifts between reads (a user's `updatedAt` changes, a user is added/removed), an ordered List reports `~` diffs on every shifted index even when the data is unchanged. A Set hid this.
2. **Pagination boundary races** — `Read` paginates with `offset += 1000` and no sort. Offset-based pagination without a stable sort can skip or duplicate users at page boundaries if the underlying order changes between page fetches.

### Change

```go
params := &iam.ListUsersParams{
    Limit: lo.ToPtr(1000),
    Sorts: &[]iam.ListUsersParamsSorts{iam.ListUsersParamsSortsIdAsc},
}
```

Sorting by `id` (immutable, unique) makes both pagination and list ordering deterministic across reads.

### Performance impact (from #317)

`terraform plan` for `astro_users` improved from ~30s to ~1s for an organization with ~1000 users — nested Set hashing of complex objects is the dominant cost; List avoids it.

## 🎟 Issue(s)
N/A — follow-up to #317

## 🧪 Functional Testing

- `go build ./...` — clean
- `go vet ./internal/provider/datasources/` — clean
- Pre-commit hook (docs generation) — clean, no doc changes (the sort is internal to `Read` and not part of the rendered schema)

## 📋 Checklist

- [x] Added/updated applicable tests (no new tests — change is an internal API parameter; existing acceptance test `TestAcc_DataSourceUsers` exercises the read path)
- [x] Updated any related documentation (none required — schema/docs unchanged)
- [x] Breaking changes are clearly documented (see warning above; requires v2.0.0)