### PR TITLE
Fix dr_region validation failing when set from an unknown value

### DIFF
--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -556,8 +556,8 @@ func validateAwsConfig(ctx context.Context, data *models.ClusterResource) diag.D
 	}
 
 	// DR validation
-	if !data.IsDrEnabled.IsNull() && data.IsDrEnabled.ValueBool() {
-		if data.DrRegion.IsNull() || data.DrRegion.IsUnknown() {
+	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.IsUnknown() && data.IsDrEnabled.ValueBool() {
+		if data.DrRegion.IsNull() {
 			diags.AddError(
 				"dr_region is required when is_dr_enabled is true",
 				"Please set dr_region to the secondary region for Disaster Recovery",

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -582,6 +582,28 @@ resource "astro_cluster" "%v" {
 `, clusterName, clusterName),
 				ExpectError: regexp.MustCompile(`dr_region is required when is_dr_enabled is true`),
 			},
+			// Test: DR enabled with dr_region derived from an unknown value (e.g. a Terraform
+			// variable or conditional) must not fail validation
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "terraform_data" "dr_region" {
+	input = "us-west-1"
+}
+
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "us-east-1"
+	cloud_provider = "AWS"
+	vpc_subnet_range = "172.20.0.0/20"
+	is_dr_enabled = true
+	dr_region = terraform_data.dr_region.output
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 			// Test: DR enabled on Azure should fail
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`


### PR DESCRIPTION
## Problem

Setting `dr_region` from a Terraform variable or conditional fails validation:

```hcl
is_dr_enabled = true
dr_region     = var.go_west ? "us-west-1" : "us-east-1"
# Error: dr_region is required when is_dr_enabled is true
```

A static string works fine. Reported in #197.

## Root cause

`ClusterResource.ValidateConfig` (`validateAwsConfig`) raised the error when `dr_region` was either null **or unknown**. A value derived from a variable/conditional is unknown at validate/early-plan time, so it was wrongly treated as missing.

## Fix

Only error when `dr_region` is known to be null; skip when unknown and defer to apply time. Also guard `is_dr_enabled` with `IsUnknown()`. This matches the convention already used for `is_dr_enabled` elsewhere in the file and the same fix applied in #246 (notification channels with Terraform variables).

## Test

Adds a regression step to `TestAcc_ResourceClusterDrValidation` that drives `dr_region` from `terraform_data.output` (unknown on first plan), asserting validation passes. `PlanOnly` keeps it at the validation layer without creating a real cluster.

Fixes #197