### PR TITLE
add gcp disaster recovery support for astro cluster

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -35,8 +35,11 @@ output "cluster" {
 - `cloud_provider` (String) Cluster cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
 - `created_at` (String) Cluster creation timestamp
 - `db_instance_type` (String) Cluster database instance type
+- `dr_pod_subnet_range` (String) The disaster recovery subnet range for pods (GCP Only).
 - `dr_region` (String) The secondary region for Disaster Recovery
 - `dr_secondary_vpc_cidr` (String) Secondary CIDR for pod networking in the DR region (AWS only)
+- `dr_service_peering_range` (String) The disaster recovery service peering range (GCP Only).
+- `dr_service_subnet_range` (String) The disaster recovery service subnet range (GCP Only).
 - `dr_vpc_subnet_range` (String) The VPC subnet range for the Disaster Recovery region
 - `enable_replication_time_control` (Boolean) Whether S3 Replication Time Control is enabled for Disaster Recovery (AWS only)
 - `health_status` (Attributes) Cluster health status (see [below for nested schema](#nestedatt--health_status))

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -53,8 +53,11 @@ Read-Only:
 - `cloud_provider` (String) Cluster cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
 - `created_at` (String) Cluster creation timestamp
 - `db_instance_type` (String) Cluster database instance type
+- `dr_pod_subnet_range` (String) The disaster recovery subnet range for pods (GCP Only).
 - `dr_region` (String) The secondary region for Disaster Recovery
 - `dr_secondary_vpc_cidr` (String) Secondary CIDR for pod networking in the DR region (AWS only)
+- `dr_service_peering_range` (String) The disaster recovery service peering range (GCP Only).
+- `dr_service_subnet_range` (String) The disaster recovery service subnet range (GCP Only).
 - `dr_vpc_subnet_range` (String) The VPC subnet range for the Disaster Recovery region
 - `enable_replication_time_control` (Boolean) Whether S3 Replication Time Control is enabled for Disaster Recovery (AWS only)
 - `health_status` (Attributes) Cluster health status (see [below for nested schema](#nestedatt--clusters--health_status))

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -61,6 +61,24 @@ resource "astro_cluster" "gcp_example" {
   workspace_ids         = []
 }
 
+resource "astro_cluster" "gcp_dr_example" {
+  type                     = "DEDICATED"
+  name                     = "my dr-enabled gcp cluster"
+  region                   = "us-central1"
+  cloud_provider           = "GCP"
+  pod_subnet_range         = "172.21.0.0/19"
+  service_peering_range    = "172.23.0.0/20"
+  service_subnet_range     = "172.22.0.0/22"
+  vpc_subnet_range         = "172.20.0.0/22"
+  workspace_ids            = []
+  is_dr_enabled            = true
+  dr_region                = "us-east1"
+  dr_vpc_subnet_range      = "172.20.4.0/22"
+  dr_pod_subnet_range      = "100.67.0.0/16"
+  dr_service_peering_range = "100.69.0.0/21"
+  dr_service_subnet_range  = "100.68.0.0/22"
+}
+
 // Import an existing cluster
 import {
   id = "clozc036j01to01jrlgvuf98d" // ID of the existing cluster
@@ -93,8 +111,11 @@ resource "astro_cluster" "imported_cluster" {
 
 ### Optional
 
+- `dr_pod_subnet_range` (String) The disaster recovery subnet range for pods (GCP Only).
 - `dr_region` (String) The secondary region for Disaster Recovery. Required when `is_dr_enabled` is true. Cannot be changed once set.
 - `dr_secondary_vpc_cidr` (String) Secondary CIDR for pod networking in the DR region (AWS only). Cannot be changed once set.
+- `dr_service_peering_range` (String) The disaster recovery service peering range (GCP Only).
+- `dr_service_subnet_range` (String) The disaster recovery service subnet range (GCP Only).
 - `dr_vpc_subnet_range` (String) The VPC subnet range for the Disaster Recovery region. Only valid when `is_dr_enabled` is true. Cannot be changed once set.
 - `enable_replication_time_control` (Boolean) Whether to enable S3 Replication Time Control for Disaster Recovery. Only valid when `is_dr_enabled` is true (AWS only).
 - `is_dr_enabled` (Boolean) Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.

--- a/examples/resources/astro_cluster/resource.tf
+++ b/examples/resources/astro_cluster/resource.tf
@@ -46,6 +46,24 @@ resource "astro_cluster" "gcp_example" {
   workspace_ids         = []
 }
 
+resource "astro_cluster" "gcp_dr_example" {
+  type                     = "DEDICATED"
+  name                     = "my dr-enabled gcp cluster"
+  region                   = "us-central1"
+  cloud_provider           = "GCP"
+  pod_subnet_range         = "172.21.0.0/19"
+  service_peering_range    = "172.23.0.0/20"
+  service_subnet_range     = "172.22.0.0/22"
+  vpc_subnet_range         = "172.20.0.0/22"
+  workspace_ids            = []
+  is_dr_enabled            = true
+  dr_region                = "us-east1"
+  dr_vpc_subnet_range      = "172.20.4.0/22"
+  dr_pod_subnet_range      = "100.67.0.0/16"
+  dr_service_peering_range = "100.69.0.0/21"
+  dr_service_subnet_range  = "100.68.0.0/22"
+}
+
 // Import an existing cluster
 import {
   id = "clozc036j01to01jrlgvuf98d" // ID of the existing cluster

--- a/internal/clients/iam/api.gen.go
+++ b/internal/clients/iam/api.gen.go
@@ -286,6 +286,9 @@ type ApiToken struct {
 	// Kind The kind of the API token.
 	Kind ApiTokenKind `json:"kind"`
 
+	// LastRotatedAt The time when the API token was last rotated in UTC, formatted as `YYYY-MM-DDTHH:MM:SSZ`.
+	LastRotatedAt *time.Time `json:"lastRotatedAt,omitempty"`
+
 	// LastUsedAt The time when the API token was last used in UTC, formatted as `YYYY-MM-DDTHH:MM:SSZ`.
 	LastUsedAt *time.Time `json:"lastUsedAt,omitempty"`
 

--- a/internal/clients/platform/api.gen.go
+++ b/internal/clients/platform/api.gen.go
@@ -5264,7 +5264,7 @@ func (t CreateNotificationChannelRequest) AsCreateDagTriggerNotificationChannelR
 
 // FromCreateDagTriggerNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateDagTriggerNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateDagTriggerNotificationChannelRequest(v CreateDagTriggerNotificationChannelRequest) error {
-	v.Type = "CreateDagTriggerNotificationChannelRequest"
+	v.Type = "DAG_TRIGGER"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5272,7 +5272,7 @@ func (t *CreateNotificationChannelRequest) FromCreateDagTriggerNotificationChann
 
 // MergeCreateDagTriggerNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateDagTriggerNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateDagTriggerNotificationChannelRequest(v CreateDagTriggerNotificationChannelRequest) error {
-	v.Type = "CreateDagTriggerNotificationChannelRequest"
+	v.Type = "DAG_TRIGGER"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5292,7 +5292,7 @@ func (t CreateNotificationChannelRequest) AsCreateEmailNotificationChannelReques
 
 // FromCreateEmailNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateEmailNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateEmailNotificationChannelRequest(v CreateEmailNotificationChannelRequest) error {
-	v.Type = "CreateEmailNotificationChannelRequest"
+	v.Type = "EMAIL"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5300,7 +5300,7 @@ func (t *CreateNotificationChannelRequest) FromCreateEmailNotificationChannelReq
 
 // MergeCreateEmailNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateEmailNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateEmailNotificationChannelRequest(v CreateEmailNotificationChannelRequest) error {
-	v.Type = "CreateEmailNotificationChannelRequest"
+	v.Type = "EMAIL"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5320,7 +5320,7 @@ func (t CreateNotificationChannelRequest) AsCreateOpsgenieNotificationChannelReq
 
 // FromCreateOpsgenieNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateOpsgenieNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateOpsgenieNotificationChannelRequest(v CreateOpsgenieNotificationChannelRequest) error {
-	v.Type = "CreateOpsgenieNotificationChannelRequest"
+	v.Type = "OPSGENIE"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5328,7 +5328,7 @@ func (t *CreateNotificationChannelRequest) FromCreateOpsgenieNotificationChannel
 
 // MergeCreateOpsgenieNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateOpsgenieNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateOpsgenieNotificationChannelRequest(v CreateOpsgenieNotificationChannelRequest) error {
-	v.Type = "CreateOpsgenieNotificationChannelRequest"
+	v.Type = "OPSGENIE"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5348,7 +5348,7 @@ func (t CreateNotificationChannelRequest) AsCreatePagerDutyNotificationChannelRe
 
 // FromCreatePagerDutyNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreatePagerDutyNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreatePagerDutyNotificationChannelRequest(v CreatePagerDutyNotificationChannelRequest) error {
-	v.Type = "CreatePagerDutyNotificationChannelRequest"
+	v.Type = "PAGERDUTY"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5356,7 +5356,7 @@ func (t *CreateNotificationChannelRequest) FromCreatePagerDutyNotificationChanne
 
 // MergeCreatePagerDutyNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreatePagerDutyNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreatePagerDutyNotificationChannelRequest(v CreatePagerDutyNotificationChannelRequest) error {
-	v.Type = "CreatePagerDutyNotificationChannelRequest"
+	v.Type = "PAGERDUTY"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5376,7 +5376,7 @@ func (t CreateNotificationChannelRequest) AsCreateSlackNotificationChannelReques
 
 // FromCreateSlackNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateSlackNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateSlackNotificationChannelRequest(v CreateSlackNotificationChannelRequest) error {
-	v.Type = "CreateSlackNotificationChannelRequest"
+	v.Type = "SLACK"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5384,7 +5384,7 @@ func (t *CreateNotificationChannelRequest) FromCreateSlackNotificationChannelReq
 
 // MergeCreateSlackNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateSlackNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateSlackNotificationChannelRequest(v CreateSlackNotificationChannelRequest) error {
-	v.Type = "CreateSlackNotificationChannelRequest"
+	v.Type = "SLACK"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5409,15 +5409,15 @@ func (t CreateNotificationChannelRequest) ValueByDiscriminator() (interface{}, e
 		return nil, err
 	}
 	switch discriminator {
-	case "CreateDagTriggerNotificationChannelRequest":
+	case "DAG_TRIGGER":
 		return t.AsCreateDagTriggerNotificationChannelRequest()
-	case "CreateEmailNotificationChannelRequest":
+	case "EMAIL":
 		return t.AsCreateEmailNotificationChannelRequest()
-	case "CreateOpsgenieNotificationChannelRequest":
+	case "OPSGENIE":
 		return t.AsCreateOpsgenieNotificationChannelRequest()
-	case "CreatePagerDutyNotificationChannelRequest":
+	case "PAGERDUTY":
 		return t.AsCreatePagerDutyNotificationChannelRequest()
-	case "CreateSlackNotificationChannelRequest":
+	case "SLACK":
 		return t.AsCreateSlackNotificationChannelRequest()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
@@ -6029,15 +6029,15 @@ func (t UpdateNotificationChannelRequest) ValueByDiscriminator() (interface{}, e
 		return nil, err
 	}
 	switch discriminator {
-	case "UpdateDagTriggerNotificationChannelRequest":
+	case "DAG_TRIGGER":
 		return t.AsUpdateDagTriggerNotificationChannelRequest()
-	case "UpdateEmailNotificationChannelRequest":
+	case "EMAIL":
 		return t.AsUpdateEmailNotificationChannelRequest()
-	case "UpdateOpsgenieNotificationChannelRequest":
+	case "OPSGENIE":
 		return t.AsUpdateOpsgenieNotificationChannelRequest()
-	case "UpdatePagerDutyNotificationChannelRequest":
+	case "PAGERDUTY":
 		return t.AsUpdatePagerDutyNotificationChannelRequest()
-	case "UpdateSlackNotificationChannelRequest":
+	case "SLACK":
 		return t.AsUpdateSlackNotificationChannelRequest()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)

--- a/internal/clients/platform/api.gen.go
+++ b/internal/clients/platform/api.gen.go
@@ -617,6 +617,7 @@ const (
 	OrganizationSupportPlanENTERPRISE                 OrganizationSupportPlan = "ENTERPRISE"
 	OrganizationSupportPlanENTERPRISEBUSINESSCRITICAL OrganizationSupportPlan = "ENTERPRISE_BUSINESS_CRITICAL"
 	OrganizationSupportPlanENTERPRISEV2               OrganizationSupportPlan = "ENTERPRISE_V2"
+	OrganizationSupportPlanIBMENTERPRISE              OrganizationSupportPlan = "IBM_ENTERPRISE"
 	OrganizationSupportPlanINACTIVE                   OrganizationSupportPlan = "INACTIVE"
 	OrganizationSupportPlanINTERNAL                   OrganizationSupportPlan = "INTERNAL"
 	OrganizationSupportPlanPOV                        OrganizationSupportPlan = "POV"
@@ -1266,16 +1267,25 @@ type Cluster struct {
 	// DbInstanceType The type of database instance that is used for the cluster.
 	DbInstanceType string `json:"dbInstanceType"`
 
+	// DrPodSubnetRange The disaster recovery subnet range for Pods. For GCP clusters only.
+	DrPodSubnetRange *string `json:"drPodSubnetRange,omitempty"`
+
 	// DrRegion The secondary region for Disaster Recovery for the cluster.
 	DrRegion string `json:"drRegion"`
 
 	// DrSecondaryVpcCidr The secondary CIDR for the DR region. For AWS clusters only.
 	DrSecondaryVpcCidr *string `json:"drSecondaryVpcCidr,omitempty"`
 
-	// DrVpcSubnetRange The VPC subnet range for the DR region. For AWS clusters only.
+	// DrServicePeeringRange The disaster recovery service peering range. For GCP clusters only.
+	DrServicePeeringRange *string `json:"drServicePeeringRange,omitempty"`
+
+	// DrServiceSubnetRange The disaster recovery service subnet range. For GCP clusters only.
+	DrServiceSubnetRange *string `json:"drServiceSubnetRange,omitempty"`
+
+	// DrVpcSubnetRange The VPC subnet range for the DR region.
 	DrVpcSubnetRange *string `json:"drVpcSubnetRange,omitempty"`
 
-	// EnableReplicationTimeControl Whether S3 Replication Time Control is enabled for DR.
+	// EnableReplicationTimeControl Whether Bucket Storage Replication Time Control is enabled for DR.
 	EnableReplicationTimeControl *bool `json:"enableReplicationTimeControl,omitempty"`
 
 	// FailoverInProgress Whether a failover is currently in progress.
@@ -1311,7 +1321,9 @@ type Cluster struct {
 	ProviderAccount *string `json:"providerAccount,omitempty"`
 
 	// Region The region in which the cluster is created.
-	Region           string  `json:"region"`
+	Region string `json:"region"`
+
+	// SecondaryVpcCidr The secondary VPC CIDR. For AWS clusters only.
 	SecondaryVpcCidr *string `json:"secondaryVpcCidr,omitempty"`
 
 	// ServicePeeringRange The service peering range. For GCP clusters only.
@@ -1333,8 +1345,10 @@ type Cluster struct {
 	Type ClusterType `json:"type"`
 
 	// UpdatedAt The time when the cluster was last updated in UTC. formatted as `YYYY-MM-DDTHH:MM:SSZ`.
-	UpdatedAt      time.Time `json:"updatedAt"`
-	VpcSubnetRange string    `json:"vpcSubnetRange"`
+	UpdatedAt time.Time `json:"updatedAt"`
+
+	// VpcSubnetRange The VPC subnet range.
+	VpcSubnetRange string `json:"vpcSubnetRange"`
 
 	// WorkspaceIds The list of Workspaces that are authorized to the cluster.
 	WorkspaceIds *[]string `json:"workspaceIds,omitempty"`
@@ -1525,16 +1539,16 @@ type CreateAwsClusterRequest struct {
 	// DbInstanceType The type of database instance that is used for the cluster. Required for Hybrid clusters.
 	DbInstanceType *string `json:"dbInstanceType,omitempty"`
 
-	// DrRegion The secondary region for Disaster Recovery. For AWS clusters only.
+	// DrRegion The secondary region for Disaster Recovery.
 	DrRegion *string `json:"drRegion,omitempty"`
 
-	// DrSecondaryVpcCidr The secondary CIDR for the DR region. Defaults to the primary secondary CIDR if not specified.
+	// DrSecondaryVpcCidr The secondary CIDR for the DR region. Defaults to the primary secondary CIDR if not specified. For AWS clusters only.
 	DrSecondaryVpcCidr *string `json:"drSecondaryVpcCidr,omitempty"`
 
-	// DrVpcSubnetRange The VPC subnet range for the DR region. Defaults to the primary VPC subnet range if not specified. For AWS clusters only.
+	// DrVpcSubnetRange The VPC subnet range for the DR region. Defaults to the primary VPC subnet range if not specified.
 	DrVpcSubnetRange *string `json:"drVpcSubnetRange,omitempty"`
 
-	// EnableReplicationTimeControl Whether S3 Replication Time Control should be enabled for DR for SLA backed 15 minute RPO on task logs.
+	// EnableReplicationTimeControl Whether Bucket Storage Replication Time Control should be enabled for DR on task logs.
 	EnableReplicationTimeControl *bool `json:"enableReplicationTimeControl,omitempty"`
 
 	// K8sTags The Kubernetes tags in the cluster.
@@ -1579,11 +1593,14 @@ type CreateAzureClusterRequest struct {
 	// DbInstanceType The type of database instance that is used for the cluster. Required for Hybrid clusters.
 	DbInstanceType *string `json:"dbInstanceType,omitempty"`
 
-	// DrRegion The secondary region for Disaster Recovery. For AWS clusters only.
+	// DrRegion The secondary region for Disaster Recovery.
 	DrRegion *string `json:"drRegion,omitempty"`
 
-	// DrVpcSubnetRange The VPC subnet range for the DR region. Defaults to the primary VPC subnet range if not specified. For AWS clusters only.
+	// DrVpcSubnetRange The VPC subnet range for the DR region. Defaults to the primary VPC subnet range if not specified.
 	DrVpcSubnetRange *string `json:"drVpcSubnetRange,omitempty"`
+
+	// EnableReplicationTimeControl Whether Bucket Storage Replication Time Control should be enabled for DR on task logs.
+	EnableReplicationTimeControl *bool `json:"enableReplicationTimeControl,omitempty"`
 
 	// K8sTags The Kubernetes tags in the cluster.
 	K8sTags *[]ClusterK8sTag `json:"k8sTags,omitempty"`
@@ -1626,7 +1643,7 @@ type CreateClusterRequest struct {
 
 // CreateDagDurationAlertProperties defines model for CreateDagDurationAlertProperties.
 type CreateDagDurationAlertProperties struct {
-	// DagDurationSeconds The duration of the DAG in seconds.
+	// DagDurationSeconds The duration of the DAG in seconds. Min 60 (1 minute), max 604800 (7 days).
 	DagDurationSeconds int `json:"dagDurationSeconds"`
 
 	// DeploymentId The ID of the deployment to which the alert is scoped.
@@ -2147,11 +2164,23 @@ type CreateGcpClusterRequest struct {
 	// DbInstanceType The type of database instance that is used for the cluster. Required for Hybrid clusters.
 	DbInstanceType *string `json:"dbInstanceType,omitempty"`
 
-	// DrRegion The secondary region for Disaster Recovery. For AWS clusters only.
+	// DrPodSubnetRange The disaster recovery subnet range for Pods. For GCP clusters only.
+	DrPodSubnetRange *string `json:"drPodSubnetRange,omitempty"`
+
+	// DrRegion The secondary region for Disaster Recovery.
 	DrRegion *string `json:"drRegion,omitempty"`
 
-	// DrVpcSubnetRange The VPC subnet range for the DR region. Defaults to the primary VPC subnet range if not specified. For AWS clusters only.
+	// DrServicePeeringRange The disaster recovery service peering range. For GCP clusters only.
+	DrServicePeeringRange *string `json:"drServicePeeringRange,omitempty"`
+
+	// DrServiceSubnetRange The disaster recovery service subnet range. For GCP clusters only.
+	DrServiceSubnetRange *string `json:"drServiceSubnetRange,omitempty"`
+
+	// DrVpcSubnetRange The VPC subnet range for the DR region. Defaults to the primary VPC subnet range if not specified.
 	DrVpcSubnetRange *string `json:"drVpcSubnetRange,omitempty"`
+
+	// EnableReplicationTimeControl Whether Bucket Storage Replication Time Control should be enabled for DR on task logs.
+	EnableReplicationTimeControl *bool `json:"enableReplicationTimeControl,omitempty"`
 
 	// K8sTags The Kubernetes tags in the cluster.
 	K8sTags *[]ClusterK8sTag `json:"k8sTags,omitempty"`
@@ -3362,6 +3391,9 @@ type Organization struct {
 	Product      *OrganizationProduct       `json:"product,omitempty"`
 	ProductPlans *[]OrganizationProductPlan `json:"productPlans,omitempty"`
 
+	// ShouldEnforceDedicatedClusters When true, only dedicated cluster deployments can be created.
+	ShouldEnforceDedicatedClusters bool `json:"shouldEnforceDedicatedClusters"`
+
 	// Status The Organization's status.
 	Status *OrganizationStatus `json:"status,omitempty"`
 
@@ -3485,6 +3517,9 @@ type ProviderRegion struct {
 	// Limited Whether the region is limited.
 	Limited *bool `json:"limited,omitempty"`
 
+	// Location The multi-region location code for DR compatibility.
+	Location *string `json:"location,omitempty"`
+
 	// Name The name of the region.
 	Name string `json:"name"`
 }
@@ -3574,7 +3609,7 @@ type UpdateClusterRequest struct {
 
 // UpdateDagDurationAlertProperties defines model for UpdateDagDurationAlertProperties.
 type UpdateDagDurationAlertProperties struct {
-	// DagDurationSeconds The duration of the DAG in seconds.
+	// DagDurationSeconds The duration of the DAG in seconds. Min 60 (1 minute), max 604800 (7 days).
 	DagDurationSeconds *int `json:"dagDurationSeconds,omitempty"`
 }
 
@@ -3729,8 +3764,26 @@ type UpdateDedicatedClusterRequest struct {
 	// DbInstanceType The cluster's database instance type. Required for Hybrid clusters.
 	DbInstanceType *string `json:"dbInstanceType,omitempty"`
 
+	// DrPodSubnetRange The disaster recovery subnet range for Pods. For GCP clusters only.
+	DrPodSubnetRange *string `json:"drPodSubnetRange,omitempty"`
+
+	// DrRegion The secondary region for Disaster Recovery.
+	DrRegion *string `json:"drRegion,omitempty"`
+
+	// DrServicePeeringRange The disaster recovery service peering range. For GCP clusters only.
+	DrServicePeeringRange *string `json:"drServicePeeringRange,omitempty"`
+
+	// DrServiceSubnetRange The disaster recovery service subnet range. For GCP clusters only.
+	DrServiceSubnetRange *string `json:"drServiceSubnetRange,omitempty"`
+
+	// DrVpcSubnetRange The VPC subnet range for the DR region. Defaults to the primary VPC subnet range if not specified.
+	DrVpcSubnetRange *string `json:"drVpcSubnetRange,omitempty"`
+
 	// EnableDr Set to false to disable Disaster Recovery. Enabling DR on existing clusters is only supported via the admin API.
 	EnableDr *bool `json:"enableDr,omitempty"`
+
+	// EnableReplicationTimeControl Whether Bucket Storage Replication Time Control should be enabled for DR on task logs.
+	EnableReplicationTimeControl *bool `json:"enableReplicationTimeControl,omitempty"`
 
 	// IsFailedOver Whether to trigger a DR failover for the cluster.
 	IsFailedOver *bool `json:"isFailedOver,omitempty"`
@@ -4123,6 +4176,9 @@ type UpdateOrganizationRequest struct {
 
 	// Name The name of the Organization.
 	Name string `json:"name"`
+
+	// ShouldEnforceDedicatedClusters When true, only dedicated cluster deployments can be created. Requires Team tier or higher.
+	ShouldEnforceDedicatedClusters *bool `json:"shouldEnforceDedicatedClusters,omitempty"`
 }
 
 // UpdatePagerDutyNotificationChannelRequest defines model for UpdatePagerDutyNotificationChannelRequest.
@@ -5208,7 +5264,7 @@ func (t CreateNotificationChannelRequest) AsCreateDagTriggerNotificationChannelR
 
 // FromCreateDagTriggerNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateDagTriggerNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateDagTriggerNotificationChannelRequest(v CreateDagTriggerNotificationChannelRequest) error {
-	v.Type = "DAG_TRIGGER"
+	v.Type = "CreateDagTriggerNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5216,7 +5272,7 @@ func (t *CreateNotificationChannelRequest) FromCreateDagTriggerNotificationChann
 
 // MergeCreateDagTriggerNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateDagTriggerNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateDagTriggerNotificationChannelRequest(v CreateDagTriggerNotificationChannelRequest) error {
-	v.Type = "DAG_TRIGGER"
+	v.Type = "CreateDagTriggerNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5236,7 +5292,7 @@ func (t CreateNotificationChannelRequest) AsCreateEmailNotificationChannelReques
 
 // FromCreateEmailNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateEmailNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateEmailNotificationChannelRequest(v CreateEmailNotificationChannelRequest) error {
-	v.Type = "EMAIL"
+	v.Type = "CreateEmailNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5244,7 +5300,7 @@ func (t *CreateNotificationChannelRequest) FromCreateEmailNotificationChannelReq
 
 // MergeCreateEmailNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateEmailNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateEmailNotificationChannelRequest(v CreateEmailNotificationChannelRequest) error {
-	v.Type = "EMAIL"
+	v.Type = "CreateEmailNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5264,7 +5320,7 @@ func (t CreateNotificationChannelRequest) AsCreateOpsgenieNotificationChannelReq
 
 // FromCreateOpsgenieNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateOpsgenieNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateOpsgenieNotificationChannelRequest(v CreateOpsgenieNotificationChannelRequest) error {
-	v.Type = "OPSGENIE"
+	v.Type = "CreateOpsgenieNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5272,7 +5328,7 @@ func (t *CreateNotificationChannelRequest) FromCreateOpsgenieNotificationChannel
 
 // MergeCreateOpsgenieNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateOpsgenieNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateOpsgenieNotificationChannelRequest(v CreateOpsgenieNotificationChannelRequest) error {
-	v.Type = "OPSGENIE"
+	v.Type = "CreateOpsgenieNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5292,7 +5348,7 @@ func (t CreateNotificationChannelRequest) AsCreatePagerDutyNotificationChannelRe
 
 // FromCreatePagerDutyNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreatePagerDutyNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreatePagerDutyNotificationChannelRequest(v CreatePagerDutyNotificationChannelRequest) error {
-	v.Type = "PAGERDUTY"
+	v.Type = "CreatePagerDutyNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5300,7 +5356,7 @@ func (t *CreateNotificationChannelRequest) FromCreatePagerDutyNotificationChanne
 
 // MergeCreatePagerDutyNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreatePagerDutyNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreatePagerDutyNotificationChannelRequest(v CreatePagerDutyNotificationChannelRequest) error {
-	v.Type = "PAGERDUTY"
+	v.Type = "CreatePagerDutyNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5320,7 +5376,7 @@ func (t CreateNotificationChannelRequest) AsCreateSlackNotificationChannelReques
 
 // FromCreateSlackNotificationChannelRequest overwrites any union data inside the CreateNotificationChannelRequest as the provided CreateSlackNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) FromCreateSlackNotificationChannelRequest(v CreateSlackNotificationChannelRequest) error {
-	v.Type = "SLACK"
+	v.Type = "CreateSlackNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	t.union = b
 	return err
@@ -5328,7 +5384,7 @@ func (t *CreateNotificationChannelRequest) FromCreateSlackNotificationChannelReq
 
 // MergeCreateSlackNotificationChannelRequest performs a merge with any union data inside the CreateNotificationChannelRequest, using the provided CreateSlackNotificationChannelRequest
 func (t *CreateNotificationChannelRequest) MergeCreateSlackNotificationChannelRequest(v CreateSlackNotificationChannelRequest) error {
-	v.Type = "SLACK"
+	v.Type = "CreateSlackNotificationChannelRequest"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -5353,15 +5409,15 @@ func (t CreateNotificationChannelRequest) ValueByDiscriminator() (interface{}, e
 		return nil, err
 	}
 	switch discriminator {
-	case "DAG_TRIGGER":
+	case "CreateDagTriggerNotificationChannelRequest":
 		return t.AsCreateDagTriggerNotificationChannelRequest()
-	case "EMAIL":
+	case "CreateEmailNotificationChannelRequest":
 		return t.AsCreateEmailNotificationChannelRequest()
-	case "OPSGENIE":
+	case "CreateOpsgenieNotificationChannelRequest":
 		return t.AsCreateOpsgenieNotificationChannelRequest()
-	case "PAGERDUTY":
+	case "CreatePagerDutyNotificationChannelRequest":
 		return t.AsCreatePagerDutyNotificationChannelRequest()
-	case "SLACK":
+	case "CreateSlackNotificationChannelRequest":
 		return t.AsCreateSlackNotificationChannelRequest()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
@@ -5973,15 +6029,15 @@ func (t UpdateNotificationChannelRequest) ValueByDiscriminator() (interface{}, e
 		return nil, err
 	}
 	switch discriminator {
-	case "DAG_TRIGGER":
+	case "UpdateDagTriggerNotificationChannelRequest":
 		return t.AsUpdateDagTriggerNotificationChannelRequest()
-	case "EMAIL":
+	case "UpdateEmailNotificationChannelRequest":
 		return t.AsUpdateEmailNotificationChannelRequest()
-	case "OPSGENIE":
+	case "UpdateOpsgenieNotificationChannelRequest":
 		return t.AsUpdateOpsgenieNotificationChannelRequest()
-	case "PAGERDUTY":
+	case "UpdatePagerDutyNotificationChannelRequest":
 		return t.AsUpdatePagerDutyNotificationChannelRequest()
-	case "SLACK":
+	case "UpdateSlackNotificationChannelRequest":
 		return t.AsUpdateSlackNotificationChannelRequest()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)

--- a/internal/provider/models/cluster.go
+++ b/internal/provider/models/cluster.go
@@ -42,6 +42,9 @@ type ClusterResource struct {
 	EnableReplicationTimeControl types.Bool     `tfsdk:"enable_replication_time_control"`
 	IsFailedOver                 types.Bool     `tfsdk:"is_failed_over"`
 	Timeouts                     timeouts.Value `tfsdk:"timeouts"` // To allow users to set timeouts for the resource.
+	DrPodSubnetRange             types.String   `tfsdk:"dr_pod_subnet_range"`
+	DrServicePeeringRange        types.String   `tfsdk:"dr_service_peering_range"`
+	DrServiceSubnetRange         types.String   `tfsdk:"dr_service_subnet_range"`
 }
 
 // ClusterDataSource describes the data source data model.
@@ -74,6 +77,9 @@ type ClusterDataSource struct {
 	DrSecondaryVpcCidr           types.String `tfsdk:"dr_secondary_vpc_cidr"`
 	EnableReplicationTimeControl types.Bool   `tfsdk:"enable_replication_time_control"`
 	IsFailedOver                 types.Bool   `tfsdk:"is_failed_over"`
+	DrPodSubnetRange             types.String `tfsdk:"dr_pod_subnet_range"`
+	DrServicePeeringRange        types.String `tfsdk:"dr_service_peering_range"`
+	DrServiceSubnetRange         types.String `tfsdk:"dr_service_subnet_range"`
 }
 
 type ClusterTag struct {
@@ -161,6 +167,9 @@ func (data *ClusterResource) ReadFromResponse(
 		data.DrVpcSubnetRange = types.StringPointerValue(cluster.DrVpcSubnetRange)
 		data.DrSecondaryVpcCidr = types.StringPointerValue(cluster.DrSecondaryVpcCidr)
 		data.EnableReplicationTimeControl = types.BoolPointerValue(cluster.EnableReplicationTimeControl)
+		data.DrPodSubnetRange = types.StringPointerValue(cluster.DrPodSubnetRange)
+		data.DrServicePeeringRange = types.StringPointerValue(cluster.DrServicePeeringRange)
+		data.DrServiceSubnetRange = types.StringPointerValue(cluster.DrServiceSubnetRange)
 	} else {
 		data.IsDrEnabled = types.BoolValue(false)
 		data.DrRegion = types.StringNull()
@@ -168,6 +177,9 @@ func (data *ClusterResource) ReadFromResponse(
 		data.DrVpcSubnetRange = types.StringNull()
 		data.DrSecondaryVpcCidr = types.StringNull()
 		data.EnableReplicationTimeControl = types.BoolNull()
+		data.DrPodSubnetRange = types.StringNull()
+		data.DrServicePeeringRange = types.StringNull()
+		data.DrServiceSubnetRange = types.StringNull()
 	}
 
 	return nil
@@ -227,6 +239,9 @@ func (data *ClusterDataSource) ReadFromResponse(
 		data.DrVpcSubnetRange = types.StringPointerValue(cluster.DrVpcSubnetRange)
 		data.DrSecondaryVpcCidr = types.StringPointerValue(cluster.DrSecondaryVpcCidr)
 		data.EnableReplicationTimeControl = types.BoolPointerValue(cluster.EnableReplicationTimeControl)
+		data.DrPodSubnetRange = types.StringPointerValue(cluster.DrPodSubnetRange)
+		data.DrServicePeeringRange = types.StringPointerValue(cluster.DrServicePeeringRange)
+		data.DrServiceSubnetRange = types.StringPointerValue(cluster.DrServiceSubnetRange)
 	} else {
 		data.IsDrEnabled = types.BoolValue(false)
 		data.DrRegion = types.StringNull()
@@ -234,6 +249,9 @@ func (data *ClusterDataSource) ReadFromResponse(
 		data.DrVpcSubnetRange = types.StringNull()
 		data.DrSecondaryVpcCidr = types.StringNull()
 		data.EnableReplicationTimeControl = types.BoolNull()
+		data.DrPodSubnetRange = types.StringNull()
+		data.DrServicePeeringRange = types.StringNull()
+		data.DrServiceSubnetRange = types.StringNull()
 	}
 
 	return nil

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -758,6 +758,18 @@ func validateGcpConfig(ctx context.Context, data *models.ClusterResource) diag.D
 				"Please set dr_pod_subnet_range",
 			)
 		}
+		if data.DrServicePeeringRange.IsNull() || data.DrServicePeeringRange.IsUnknown() {
+			diags.AddError(
+				"dr_service_peering_range is required for 'GCP' cluster when is_dr_enabled is true",
+				"Please set dr_service_peering_range",
+			)
+		}
+		if data.DrServiceSubnetRange.IsNull() || data.DrServiceSubnetRange.IsUnknown() {
+			diags.AddError(
+				"dr_service_subnet_range is required for 'GCP' cluster when is_dr_enabled is true",
+				"Please set dr_service_subnet_range",
+			)
+		}
 	}
 
 	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.ValueBool() {

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -746,6 +746,12 @@ func validateGcpConfig(ctx context.Context, data *models.ClusterResource) diag.D
 				"Please set dr_region to the secondary region for Disaster Recovery",
 			)
 		}
+		if data.DrVpcSubnetRange.IsNull() || data.DrVpcSubnetRange.IsUnknown() {
+			diags.AddError(
+				"dr_vpc_subnet_range is required for 'GCP' cluster when is_dr_enabled is true",
+				"Please set dr_vpc_subnet_range",
+			)
+		}
 	}
 
 	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.ValueBool() {

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -752,6 +752,12 @@ func validateGcpConfig(ctx context.Context, data *models.ClusterResource) diag.D
 				"Please set dr_vpc_subnet_range",
 			)
 		}
+		if data.DrPodSubnetRange.IsNull() || data.DrPodSubnetRange.IsUnknown() {
+			diags.AddError(
+				"dr_pod_subnet_range is required for 'GCP' cluster when is_dr_enabled is true",
+				"Please set dr_pod_subnet_range",
+			)
+		}
 	}
 
 	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.ValueBool() {

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -156,16 +156,21 @@ func (r *ClusterResource) Create(
 		}
 	case platform.ClusterCloudProviderGCP:
 		createGcpDedicatedClusterRequest := platform.CreateGcpClusterRequest{
-			CloudProvider:       platform.CreateGcpClusterRequestCloudProvider(data.CloudProvider.ValueString()),
-			Name:                data.Name.ValueString(),
-			NodePools:           nil,
-			PodSubnetRange:      data.PodSubnetRange.ValueString(),
-			ProviderAccount:     data.ProviderAccount.ValueStringPointer(),
-			Region:              data.Region.ValueString(),
-			ServicePeeringRange: data.ServicePeeringRange.ValueString(),
-			ServiceSubnetRange:  data.ServiceSubnetRange.ValueString(),
-			Type:                platform.CreateGcpClusterRequestType(data.Type.ValueString()),
-			VpcSubnetRange:      data.VpcSubnetRange.ValueString(),
+			CloudProvider:         platform.CreateGcpClusterRequestCloudProvider(data.CloudProvider.ValueString()),
+			Name:                  data.Name.ValueString(),
+			NodePools:             nil,
+			PodSubnetRange:        data.PodSubnetRange.ValueString(),
+			ProviderAccount:       data.ProviderAccount.ValueStringPointer(),
+			Region:                data.Region.ValueString(),
+			ServicePeeringRange:   data.ServicePeeringRange.ValueString(),
+			ServiceSubnetRange:    data.ServiceSubnetRange.ValueString(),
+			Type:                  platform.CreateGcpClusterRequestType(data.Type.ValueString()),
+			VpcSubnetRange:        data.VpcSubnetRange.ValueString(),
+			DrRegion:              data.DrRegion.ValueStringPointer(),
+			DrVpcSubnetRange:      data.DrVpcSubnetRange.ValueStringPointer(),
+			DrPodSubnetRange:      data.DrPodSubnetRange.ValueStringPointer(),
+			DrServicePeeringRange: data.DrServicePeeringRange.ValueStringPointer(),
+			DrServiceSubnetRange:  data.DrServiceSubnetRange.ValueStringPointer(),
 		}
 
 		// workspaceIds
@@ -554,6 +559,24 @@ func validateAwsConfig(ctx context.Context, data *models.ClusterResource) diag.D
 			"Please remove service_subnet_range",
 		)
 	}
+	if !data.DrPodSubnetRange.IsNull() {
+		diags.AddError(
+			"dr_pod_subnet_range is not allowed for 'AWS' cluster",
+			"Please remove dr_pod_subnet_range",
+		)
+	}
+	if !data.DrServicePeeringRange.IsNull() {
+		diags.AddError(
+			"dr_service_peering_range is not allowed for 'AWS' cluster",
+			"Please remove dr_service_peering_range",
+		)
+	}
+	if !data.DrServiceSubnetRange.IsNull() {
+		diags.AddError(
+			"dr_service_subnet_range is not allowed for 'AWS' cluster",
+			"Please remove dr_service_subnet_range",
+		)
+	}
 
 	// DR validation
 	if !data.IsDrEnabled.IsNull() && data.IsDrEnabled.ValueBool() {
@@ -650,6 +673,24 @@ func validateAzureConfig(ctx context.Context, data *models.ClusterResource) diag
 			"Please remove enable_replication_time_control",
 		)
 	}
+	if !data.DrPodSubnetRange.IsNull() {
+		diags.AddError(
+			"dr_pod_subnet_range is not allowed for 'AZURE' cluster",
+			"Please remove dr_pod_subnet_range",
+		)
+	}
+	if !data.DrServicePeeringRange.IsNull() {
+		diags.AddError(
+			"dr_service_peering_range is not allowed for 'AZURE' cluster",
+			"Please remove dr_service_peering_range",
+		)
+	}
+	if !data.DrServiceSubnetRange.IsNull() {
+		diags.AddError(
+			"dr_service_subnet_range is not allowed for 'AZURE' cluster",
+			"Please remove dr_service_subnet_range",
+		)
+	}
 
 	return diags
 }
@@ -690,37 +731,54 @@ func validateGcpConfig(ctx context.Context, data *models.ClusterResource) diag.D
 			"Please remove secondary_vpc_cidr",
 		)
 	}
-
-	// DR is not supported for GCP clusters
-	if !data.IsDrEnabled.IsNull() && data.IsDrEnabled.ValueBool() {
-		diags.AddError(
-			"Disaster Recovery is not supported for 'GCP' clusters",
-			"Please remove is_dr_enabled, dr_region, dr_vpc_subnet_range, and dr_secondary_vpc_cidr",
-		)
-	}
-	if !data.DrRegion.IsNull() {
-		diags.AddError(
-			"dr_region is not allowed for 'GCP' cluster",
-			"Please remove dr_region",
-		)
-	}
-	if !data.DrVpcSubnetRange.IsNull() {
-		diags.AddError(
-			"dr_vpc_subnet_range is not allowed for 'GCP' cluster",
-			"Please remove dr_vpc_subnet_range",
-		)
-	}
 	if !data.DrSecondaryVpcCidr.IsNull() {
 		diags.AddError(
 			"dr_secondary_vpc_cidr is not allowed for 'GCP' cluster",
 			"Please remove dr_secondary_vpc_cidr",
 		)
 	}
-	if !data.EnableReplicationTimeControl.IsNull() {
-		diags.AddError(
-			"enable_replication_time_control is not allowed for 'GCP' cluster",
-			"Please remove enable_replication_time_control",
-		)
+
+	// DR validation
+	if !data.IsDrEnabled.IsNull() && data.IsDrEnabled.ValueBool() {
+		if data.DrRegion.IsNull() || data.DrRegion.IsUnknown() {
+			diags.AddError(
+				"dr_region is required when is_dr_enabled is true",
+				"Please set dr_region to the secondary region for Disaster Recovery",
+			)
+		}
+	}
+
+	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.ValueBool() {
+		if !data.DrVpcSubnetRange.IsNull() {
+			diags.AddError(
+				"dr_vpc_subnet_range is only valid when is_dr_enabled is true",
+				"Please remove dr_vpc_subnet_range or set is_dr_enabled to true",
+			)
+		}
+		if !data.EnableReplicationTimeControl.IsNull() {
+			diags.AddError(
+				"enable_replication_time_control is only valid when is_dr_enabled is true",
+				"Please remove enable_replication_time_control or set is_dr_enabled to true",
+			)
+		}
+		if !data.DrPodSubnetRange.IsNull() {
+			diags.AddError(
+				"dr_pod_subnet_range is only valid when is_dr_enabled is true",
+				"Please remove dr_pod_subnet_range or set is_dr_enabled to true",
+			)
+		}
+		if !data.DrServicePeeringRange.IsNull() {
+			diags.AddError(
+				"dr_service_peering_range is only valid when is_dr_enabled is true",
+				"Please remove dr_service_peering_range or set is_dr_enabled to true",
+			)
+		}
+		if !data.DrServiceSubnetRange.IsNull() {
+			diags.AddError(
+				"dr_service_subnet_range is only valid when is_dr_enabled is true",
+				"Please remove dr_service_subnet_range or set is_dr_enabled to true",
+			)
+		}
 	}
 
 	return diags

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -574,13 +574,15 @@ func TestAcc_ResourceClusterGcpWithDr(t *testing.T) {
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
 					cluster(clusterInput{
-						Name:             gcpClusterName,
-						Region:           "us-central1",
-						CloudProvider:    "GCP",
-						IsDrEnabled:      true,
-						DrRegion:         "us-east1",
-						DrVpcSubnetRange: "172.24.0.0/20",
-						DrPodSubnetRange: "172.25.0.0/19",
+						Name:                  gcpClusterName,
+						Region:                "us-central1",
+						CloudProvider:         "GCP",
+						IsDrEnabled:           true,
+						DrRegion:              "us-east1",
+						DrVpcSubnetRange:      "172.24.0.0/20",
+						DrPodSubnetRange:      "172.25.0.0/19",
+						DrServicePeeringRange: "172.27.0.0/20",
+						DrServiceSubnetRange:  "172.26.0.0/22",
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(gcpResourceVar, "name", gcpClusterName),
@@ -880,6 +882,8 @@ type clusterInput struct {
 	DrRegion                           string
 	DrVpcSubnetRange                   string
 	DrPodSubnetRange                   string
+	DrServicePeeringRange              string
+	DrServiceSubnetRange               string
 	DrSecondaryVpcCidr                 string
 	EnableReplicationTimeControl       bool
 }
@@ -913,6 +917,14 @@ func cluster(input clusterInput) string {
 		if input.DrPodSubnetRange != "" {
 			drFields += fmt.Sprintf(`
 	dr_pod_subnet_range = "%v"`, input.DrPodSubnetRange)
+		}
+		if input.DrServicePeeringRange != "" {
+			drFields += fmt.Sprintf(`
+	dr_service_peering_range = "%v"`, input.DrServicePeeringRange)
+		}
+		if input.DrServiceSubnetRange != "" {
+			drFields += fmt.Sprintf(`
+	dr_service_subnet_range = "%v"`, input.DrServiceSubnetRange)
 		}
 		if input.DrSecondaryVpcCidr != "" {
 			drFields += fmt.Sprintf(`

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -416,7 +416,7 @@ func TestAcc_ResourceClusterGcpWithDedicatedDeployments(t *testing.T) {
 					resource.TestCheckResourceAttrSet(gcpResourceVar, "service_peering_range"),
 					resource.TestCheckResourceAttrSet(gcpResourceVar, "service_subnet_range"),
 					resource.TestCheckResourceAttr(gcpResourceVar, "workspace_ids.#", "1"),
-					// Check DR fields are not set for GCP cluster
+					// Check DR fields are not set for non-DR cluster
 					resource.TestCheckResourceAttr(gcpResourceVar, "is_dr_enabled", "false"),
 
 					// Check via API that cluster exists
@@ -556,6 +556,55 @@ func TestAcc_ResourceClusterAwsWithDr(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceClusterGcpWithDr(t *testing.T) {
+	if os.Getenv(SKIP_CLUSTER_RESOURCE_TESTS) == "True" {
+		t.Skip(SKIP_CLUSTER_RESOURCE_TESTS_REASON)
+	}
+
+	namePrefix := utils.GenerateTestResourceName(10)
+	gcpClusterName := fmt.Sprintf("%v_gcp_dr", namePrefix)
+	gcpResourceVar := fmt.Sprintf("astro_cluster.%v", gcpClusterName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
+		CheckDestroy:             testAccCheckClusterExistence(t, gcpClusterName, true, false),
+		Steps: []resource.TestStep{
+			// Create GCP cluster with DR enabled
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					cluster(clusterInput{
+						Name:          gcpClusterName,
+						Region:        "us-central1",
+						CloudProvider: "GCP",
+						IsDrEnabled:   true,
+						DrRegion:      "us-east1",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(gcpResourceVar, "name", gcpClusterName),
+					resource.TestCheckResourceAttr(gcpResourceVar, "region", "us-central1"),
+					resource.TestCheckResourceAttr(gcpResourceVar, "cloud_provider", "GCP"),
+					resource.TestCheckResourceAttrSet(gcpResourceVar, "pod_subnet_range"),
+					// Check DR fields
+					resource.TestCheckResourceAttr(gcpResourceVar, "is_dr_enabled", "true"),
+					resource.TestCheckResourceAttr(gcpResourceVar, "dr_region", "us-east1"),
+					resource.TestCheckResourceAttrSet(gcpResourceVar, "is_failed_over"),
+
+					testAccCheckClusterExistence(t, gcpClusterName, true, true),
+				),
+			},
+			// Import existing DR cluster
+			{
+				PreConfig:               func() { waitForClusterStableState(t, gcpClusterName) },
+				ResourceName:            gcpResourceVar,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"health_status", "health_status.value", "status"},
+			},
+		},
+	})
+}
+
 func TestAcc_ResourceClusterDrValidation(t *testing.T) {
 	if os.Getenv(SKIP_CLUSTER_RESOURCE_TESTS) == "True" {
 		t.Skip(SKIP_CLUSTER_RESOURCE_TESTS_REASON)
@@ -598,25 +647,6 @@ resource "astro_cluster" "%v" {
 `, clusterName, clusterName),
 				ExpectError: regexp.MustCompile(`Disaster Recovery is not supported for 'AZURE' clusters`),
 			},
-			// Test: DR enabled on GCP should fail
-			{
-				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
-resource "astro_cluster" "%v" {
-	name = "%v"
-	type = "DEDICATED"
-	region = "us-central1"
-	cloud_provider = "GCP"
-	vpc_subnet_range = "172.20.0.0/20"
-	pod_subnet_range = "172.21.0.0/19"
-	service_peering_range = "172.23.0.0/20"
-	service_subnet_range = "172.22.0.0/22"
-	is_dr_enabled = true
-	dr_region = "us-east1"
-	workspace_ids = []
-}
-`, clusterName, clusterName),
-				ExpectError: regexp.MustCompile(`Disaster Recovery is not supported for 'GCP' clusters`),
-			},
 			// Test: dr_region on Azure should fail
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
@@ -631,24 +661,6 @@ resource "astro_cluster" "%v" {
 }
 `, clusterName, clusterName),
 				ExpectError: regexp.MustCompile(`dr_region is not allowed for 'AZURE' cluster`),
-			},
-			// Test: dr_region on GCP should fail
-			{
-				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
-resource "astro_cluster" "%v" {
-	name = "%v"
-	type = "DEDICATED"
-	region = "us-central1"
-	cloud_provider = "GCP"
-	vpc_subnet_range = "172.20.0.0/20"
-	pod_subnet_range = "172.21.0.0/19"
-	service_peering_range = "172.23.0.0/20"
-	service_subnet_range = "172.22.0.0/22"
-	dr_region = "us-east1"
-	workspace_ids = []
-}
-`, clusterName, clusterName),
-				ExpectError: regexp.MustCompile(`dr_region is not allowed for 'GCP' cluster`),
 			},
 			// Test: DR sub-fields without DR enabled on AWS should fail
 			{
@@ -681,6 +693,60 @@ resource "astro_cluster" "%v" {
 }
 `, clusterName, clusterName),
 				ExpectError: regexp.MustCompile(`enable_replication_time_control is only valid when is_dr_enabled is true`),
+			},
+			// Test: DR sub-fields without DR enabled on GCP should fail
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "us-central1"
+	cloud_provider = "GCP"
+	pod_subnet_range = "172.21.0.0/19"
+	service_peering_range = "172.23.0.0/20"
+	service_subnet_range = "172.22.0.0/22"
+	is_dr_enabled = false
+	dr_pod_subnet_range = "172.21.0.0/19"
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				ExpectError: regexp.MustCompile(`dr_pod_subnet_range is only valid when is_dr_enabled is true`),
+			},
+			// Test: DR sub-fields without DR enabled on GCP should fail
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "us-central1"
+	cloud_provider = "GCP"
+	pod_subnet_range = "172.21.0.0/19"
+	service_peering_range = "172.23.0.0/20"
+	service_subnet_range = "172.22.0.0/22"
+	is_dr_enabled = false
+    dr_service_peering_range = "172.23.0.0/20"
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				ExpectError: regexp.MustCompile(`dr_service_peering_range is only valid when is_dr_enabled is true`),
+			},
+			// Test: DR sub-fields without DR enabled on GCP should fail
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "us-central1"
+	cloud_provider = "GCP"
+	pod_subnet_range = "172.21.0.0/19"
+	service_peering_range = "172.23.0.0/20"
+	service_subnet_range = "172.22.0.0/22"
+	is_dr_enabled = false
+    dr_service_subnet_range  = "172.22.0.0/22"
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				ExpectError: regexp.MustCompile(`dr_service_subnet_range is only valid when is_dr_enabled is true`),
 			},
 		},
 	})

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -575,23 +575,23 @@ func TestAcc_ResourceClusterGcpWithDr(t *testing.T) {
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
 					cluster(clusterInput{
 						Name:                  gcpClusterName,
-						Region:                "us-central1",
+						Region:                "us-west1",
 						CloudProvider:         "GCP",
 						IsDrEnabled:           true,
-						DrRegion:              "us-east1",
+						DrRegion:              "us-west2",
 						DrVpcSubnetRange:      "172.24.0.0/20",
-						DrPodSubnetRange:      "172.25.0.0/19",
-						DrServicePeeringRange: "172.27.0.0/20",
-						DrServiceSubnetRange:  "172.26.0.0/22",
+						DrPodSubnetRange:      "100.67.0.0/16",
+						DrServicePeeringRange: "100.69.0.0/21",
+						DrServiceSubnetRange:  "100.68.0.0/22",
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(gcpResourceVar, "name", gcpClusterName),
-					resource.TestCheckResourceAttr(gcpResourceVar, "region", "us-central1"),
+					resource.TestCheckResourceAttr(gcpResourceVar, "region", "us-west1"),
 					resource.TestCheckResourceAttr(gcpResourceVar, "cloud_provider", "GCP"),
 					resource.TestCheckResourceAttrSet(gcpResourceVar, "pod_subnet_range"),
 					// Check DR fields
 					resource.TestCheckResourceAttr(gcpResourceVar, "is_dr_enabled", "true"),
-					resource.TestCheckResourceAttr(gcpResourceVar, "dr_region", "us-east1"),
+					resource.TestCheckResourceAttr(gcpResourceVar, "dr_region", "us-west2"),
 					resource.TestCheckResourceAttrSet(gcpResourceVar, "is_failed_over"),
 
 					testAccCheckClusterExistence(t, gcpClusterName, true, true),
@@ -896,9 +896,9 @@ func cluster(input clusterInput) string {
 	}
 	if input.CloudProvider == string(platform.ClusterCloudProviderGCP) {
 		gcpNetworkFields = `
-	pod_subnet_range = "172.21.0.0/19"
-	service_peering_range = "172.23.0.0/20"
-	service_subnet_range =  "172.22.0.0/22"`
+	pod_subnet_range = "100.64.0.0/16"
+	service_peering_range = "100.66.0.0/21"
+	service_subnet_range =  "100.65.0.0/22"`
 	}
 	secondaryVpcCidrField := ""
 	if input.SecondaryVpcCidr != "" {

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -574,11 +574,12 @@ func TestAcc_ResourceClusterGcpWithDr(t *testing.T) {
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
 					cluster(clusterInput{
-						Name:          gcpClusterName,
-						Region:        "us-central1",
-						CloudProvider: "GCP",
-						IsDrEnabled:   true,
-						DrRegion:      "us-east1",
+						Name:             gcpClusterName,
+						Region:           "us-central1",
+						CloudProvider:    "GCP",
+						IsDrEnabled:      true,
+						DrRegion:         "us-east1",
+						DrVpcSubnetRange: "172.24.0.0/20",
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(gcpResourceVar, "name", gcpClusterName),
@@ -702,6 +703,7 @@ resource "astro_cluster" "%v" {
 	type = "DEDICATED"
 	region = "us-central1"
 	cloud_provider = "GCP"
+	vpc_subnet_range = "172.20.0.0/20"
 	pod_subnet_range = "172.21.0.0/19"
 	service_peering_range = "172.23.0.0/20"
 	service_subnet_range = "172.22.0.0/22"
@@ -720,6 +722,7 @@ resource "astro_cluster" "%v" {
 	type = "DEDICATED"
 	region = "us-central1"
 	cloud_provider = "GCP"
+	vpc_subnet_range = "172.20.0.0/20"
 	pod_subnet_range = "172.21.0.0/19"
 	service_peering_range = "172.23.0.0/20"
 	service_subnet_range = "172.22.0.0/22"
@@ -738,6 +741,7 @@ resource "astro_cluster" "%v" {
 	type = "DEDICATED"
 	region = "us-central1"
 	cloud_provider = "GCP"
+	vpc_subnet_range = "172.20.0.0/20"
 	pod_subnet_range = "172.21.0.0/19"
 	service_peering_range = "172.23.0.0/20"
 	service_subnet_range = "172.22.0.0/22"

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -580,6 +580,7 @@ func TestAcc_ResourceClusterGcpWithDr(t *testing.T) {
 						IsDrEnabled:      true,
 						DrRegion:         "us-east1",
 						DrVpcSubnetRange: "172.24.0.0/20",
+						DrPodSubnetRange: "172.25.0.0/19",
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(gcpResourceVar, "name", gcpClusterName),
@@ -878,6 +879,7 @@ type clusterInput struct {
 	IsDrEnabled                        bool
 	DrRegion                           string
 	DrVpcSubnetRange                   string
+	DrPodSubnetRange                   string
 	DrSecondaryVpcCidr                 string
 	EnableReplicationTimeControl       bool
 }
@@ -907,6 +909,10 @@ func cluster(input clusterInput) string {
 		if input.DrVpcSubnetRange != "" {
 			drFields += fmt.Sprintf(`
 	dr_vpc_subnet_range = "%v"`, input.DrVpcSubnetRange)
+		}
+		if input.DrPodSubnetRange != "" {
+			drFields += fmt.Sprintf(`
+	dr_pod_subnet_range = "%v"`, input.DrPodSubnetRange)
 		}
 		if input.DrSecondaryVpcCidr != "" {
 			drFields += fmt.Sprintf(`

--- a/internal/provider/schemas/cluster.go
+++ b/internal/provider/schemas/cluster.go
@@ -348,15 +348,15 @@ func ClusterDataSourceSchemaAttributes() map[string]datasourceSchema.Attribute {
 			MarkdownDescription: "Whether the cluster is currently failed over to the DR region",
 			Computed:            true,
 		},
-		"dr_pod_subnet_range": resourceSchema.StringAttribute{
+		"dr_pod_subnet_range": datasourceSchema.StringAttribute{
 			MarkdownDescription: "The disaster recovery subnet range for pods (GCP Only).",
 			Computed:            true,
 		},
-		"dr_service_peering_range": resourceSchema.StringAttribute{
+		"dr_service_peering_range": datasourceSchema.StringAttribute{
 			MarkdownDescription: "The disaster recovery service peering range (GCP Only).",
 			Computed:            true,
 		},
-		"dr_service_subnet_range": resourceSchema.StringAttribute{
+		"dr_service_subnet_range": datasourceSchema.StringAttribute{
 			MarkdownDescription: "The disaster recovery service subnet range (GCP Only).",
 			Computed:            true,
 		},

--- a/internal/provider/schemas/cluster.go
+++ b/internal/provider/schemas/cluster.go
@@ -205,6 +205,21 @@ func ClusterResourceSchemaAttributes(ctx context.Context) map[string]resourceSch
 			Update: true,
 			Delete: true,
 		}),
+		"dr_pod_subnet_range": resourceSchema.StringAttribute{
+			MarkdownDescription: "The disaster recovery subnet range for pods (GCP Only).",
+			Optional:            true,
+			Computed:            true,
+		},
+		"dr_service_peering_range": resourceSchema.StringAttribute{
+			MarkdownDescription: "The disaster recovery service peering range (GCP Only).",
+			Optional:            true,
+			Computed:            true,
+		},
+		"dr_service_subnet_range": resourceSchema.StringAttribute{
+			MarkdownDescription: "The disaster recovery service subnet range (GCP Only).",
+			Optional:            true,
+			Computed:            true,
+		},
 	}
 }
 
@@ -331,6 +346,18 @@ func ClusterDataSourceSchemaAttributes() map[string]datasourceSchema.Attribute {
 		},
 		"is_failed_over": datasourceSchema.BoolAttribute{
 			MarkdownDescription: "Whether the cluster is currently failed over to the DR region",
+			Computed:            true,
+		},
+		"dr_pod_subnet_range": resourceSchema.StringAttribute{
+			MarkdownDescription: "The disaster recovery subnet range for pods (GCP Only).",
+			Computed:            true,
+		},
+		"dr_service_peering_range": resourceSchema.StringAttribute{
+			MarkdownDescription: "The disaster recovery service peering range (GCP Only).",
+			Computed:            true,
+		},
+		"dr_service_subnet_range": resourceSchema.StringAttribute{
+			MarkdownDescription: "The disaster recovery service subnet range (GCP Only).",
 			Computed:            true,
 		},
 	}

--- a/internal/provider/schemas/clusters.go
+++ b/internal/provider/schemas/clusters.go
@@ -54,6 +54,9 @@ func ClustersElementAttributeTypes() map[string]attr.Type {
 		"dr_secondary_vpc_cidr":           types.StringType,
 		"enable_replication_time_control": types.BoolType,
 		"is_failed_over":                  types.BoolType,
+		"dr_pod_subnet_range":             types.StringType,
+		"dr_service_peering_range":        types.StringType,
+		"dr_service_subnet_range":         types.StringType,
 	}
 }
 


### PR DESCRIPTION
## Description
Same as title
<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)

## 🧪 Functional Testing

terraform apply with the following main.tf

```
terraform {
  required_providers {
    astro = {
      source = "astronomer/astro"
    }
  }
}

provider "astro" {
  organization_id = "REDACTED"
  host             = "REDACTED"
}

resource "astro_cluster" "gcp_dr_example" {
  type                     = "DEDICATED"
  name                     = "my dr-enabled gcp cluster"
  region                   = "us-central1"
  cloud_provider           = "GCP"
  pod_subnet_range         = "172.21.0.0/19"
  service_peering_range    = "172.23.0.0/20"
  service_subnet_range     = "172.22.0.0/22"
  vpc_subnet_range         = "172.20.0.0/22"
  workspace_ids            = []
  is_dr_enabled            = true
  dr_region                = "us-east1"
  dr_vpc_subnet_range      = "172.20.4.0/22"
  dr_pod_subnet_range      = "100.67.0.0/16"
  dr_service_peering_range = "100.69.0.0/21"
  dr_service_subnet_range  = "100.68.0.0/22"
}
```

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->
<img width="1294" height="514" alt="image" src="https://github.com/user-attachments/assets/d8516a79-f295-41d8-ab6f-440bd55b3f7e" />

## 📋 Checklist

- [x] Added/updated applicable tests
- [x] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
