### PR TITLE
Fix scheduler_au inconsistent-result error after import

### DIFF
--- a/internal/provider/models/deployment.go
+++ b/internal/provider/models/deployment.go
@@ -186,6 +186,11 @@ func (data *DeploymentResource) ReadFromResponse(
 	if deployment.SchedulerAu != nil {
 		deploymentSchedulerAu := int64(*deployment.SchedulerAu)
 		data.SchedulerAu = types.Int64Value(deploymentSchedulerAu)
+	} else {
+		// scheduler_au is Optional+Computed - when the API doesn't return a value (e.g. STANDARD/DEDICATED
+		// deployments), it must be explicitly set to null. Otherwise it's left as whatever the prior
+		// plan/state value was (often unknown), which Terraform rejects as an invalid apply result.
+		data.SchedulerAu = types.Int64Null()
 	}
 	data.SchedulerReplicas = types.Int64Value(int64(deployment.SchedulerReplicas))
 	data.ImageTag = types.StringValue(deployment.ImageTag)
@@ -314,6 +319,8 @@ func (data *DeploymentDataSource) ReadFromResponse(
 	if deployment.SchedulerAu != nil {
 		deploymentSchedulerAu := int64(*deployment.SchedulerAu)
 		data.SchedulerAu = types.Int64Value(deploymentSchedulerAu)
+	} else {
+		data.SchedulerAu = types.Int64Null()
 	}
 	data.SchedulerReplicas = types.Int64Value(int64(deployment.SchedulerReplicas))
 	data.ImageTag = types.StringValue(deployment.ImageTag)

--- a/internal/provider/schemas/deployment.go
+++ b/internal/provider/schemas/deployment.go
@@ -224,6 +224,7 @@ func DeploymentResourceSchemaAttributes() map[string]resourceSchema.Attribute {
 		"scheduler_au": resourceSchema.Int64Attribute{
 			MarkdownDescription: "Deployment scheduler AU - required for 'HYBRID' deployments",
 			Optional:            true,
+			Computed:            true,
 			Validators: []validator.Int64{
 				int64validator.Between(5, 24),
 			},

--- a/internal/provider/schemas/deployment_test.go
+++ b/internal/provider/schemas/deployment_test.go
@@ -1,0 +1,16 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeploymentResourceSchemaAttributes_SchedulerAuIsOptionalAndComputed(t *testing.T) {
+	attributes := DeploymentResourceSchemaAttributes()
+
+	schedulerAu, ok := attributes["scheduler_au"]
+	assert.True(t, ok, "scheduler_au attribute should exist in the deployment resource schema")
+	assert.True(t, schedulerAu.IsOptional(), "scheduler_au should be Optional")
+	assert.True(t, schedulerAu.IsComputed(), "scheduler_au should be Computed to avoid drift/inconsistent-result errors when omitted from config, e.g. after import")
+}


### PR DESCRIPTION
## Description

* scheduler_au was declared Optional only (not Computed) in the deployment resource schema.
* Marks scheduler_au as Optional: true, Computed: true avoiding drift

## 🎟 Issue(s)
Fixes #176 

## 🧪 Functional Testing

Additional test added

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [ ] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
