### PR TITLE
Add Azure disaster recovery support to the cluster resource 

### DIFF
--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -58,14 +58,55 @@ jobs:
       - run: go mod download
       - run: go build -v .
 
-  testacc:
-    name: Terraform Provider Acceptance Tests
+  determine-cluster-tests:
+    name: Determine if cluster tests should run
     needs: build
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request_target'
-    timeout-minutes: 180 # 3 hours since cluster creation and cluster updates can take a while
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Determine if expensive cluster tests should run
+        id: check
+        run: |
+         git fetch --all
+         echo "CHECKING FILES FOR SKIP LOGIC..."
+         SKIP_TESTS="True"
+         FILES_TO_CHECK=(
+           "internal/provider/schemas/deployment.go"
+           "internal/provider/schemas/cluster.go"
+           "internal/provider/models/deployment.go"
+           "internal/provider/models/cluster.go"
+           "internal/provider/resources/resource_cluster.go"
+           "internal/provider/resources/resource_cluster_test.go"
+           "internal/provider/resources/resource_deployment.go"
+           "internal/provider/resources/common_cluster.go"
+         )
+         for file in "${FILES_TO_CHECK[@]}"; do
+           if git diff --name-only origin/${{ github.event.pull_request.base.ref || github.ref_name }} ${{ github.event.pull_request.head.sha || github.sha }} | grep -q "$file"; then
+             SKIP_TESTS="False"
+             break
+           fi
+         done
+         echo "SKIP_CLUSTER_RESOURCE_TESTS=$SKIP_TESTS"
+         echo "skip=$SKIP_TESTS" >> "$GITHUB_OUTPUT"
+
+  testacc:
+    name: Terraform Provider Acceptance Tests
+    needs: [build, determine-cluster-tests]
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request_target'
+    timeout-minutes: 60 # cluster resource tests run separately in testacc-cluster
     strategy:
       fail-fast: true
       matrix:
@@ -96,29 +137,6 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - run: go mod download
-      - name: Determine if expensive tests should run
-        run: |
-         git fetch --all
-         echo "CHECKING FILES FOR SKIP LOGIC..."
-         SKIP_TESTS="True"
-         FILES_TO_CHECK=(
-           "internal/provider/schemas/deployment.go"
-           "internal/provider/schemas/cluster.go"
-           "internal/provider/models/deployment.go"
-           "internal/provider/models/cluster.go"
-           "internal/provider/resources/resource_cluster.go"
-           "internal/provider/resources/resource_cluster_test.go"
-           "internal/provider/resources/resource_deployment.go"
-           "internal/provider/resources/common_cluster.go"
-         )
-         for file in "${FILES_TO_CHECK[@]}"; do
-           if git diff --name-only origin/${{ github.event.pull_request.base.ref || github.ref_name }} ${{ github.event.pull_request.head.sha || github.sha }} | grep -q "$file"; then
-             SKIP_TESTS="False"
-             break
-           fi
-         done
-         echo "SKIP_CLUSTER_RESOURCE_TESTS=$SKIP_TESTS"
-         echo "SKIP_CLUSTER_RESOURCE_TESTS=$SKIP_TESTS" >> $GITHUB_ENV
       - env:
           TF_ACC: "1"
           HYBRID_ORGANIZATION_API_TOKEN: ${{ secrets.STAGE_HYBRID_ORGANIZATION_API_TOKEN }}
@@ -143,10 +161,80 @@ jobs:
           HOSTED_NOTIFICATION_CHANNEL_ID: cmbr12fik1m7l01gpln1bgtbb
           HOSTED_DEDICATED_CLUSTER_ID: cm73vsinm07hy01pu4dq1rei2
           HOSTED_CUSTOM_ROLE_ID: cmk64yvat027n01q7f9gn5ghg
-          SKIP_CLUSTER_RESOURCE_TESTS: ${{ env.SKIP_CLUSTER_RESOURCE_TESTS }}
+          # Cluster resource tests run in the dedicated testacc-cluster job instead.
+          SKIP_CLUSTER_RESOURCE_TESTS: "True"
           REMOTE_EXECUTION_DEPLOYMENT_ID: cmng0suky152501ilj9cjlmz3
-          TESTARGS: "-failfast"
+          TESTARGS: "-failfast -parallel 9"
         run: make testacc
+
+  testacc-cluster:
+    name: Cluster tests (${{ matrix.cluster_test }})
+    needs: [build, determine-cluster-tests]
+    if: needs.determine-cluster-tests.outputs.skip == 'False'
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster_test:
+          - TestAcc_ResourceClusterAwsWithDedicatedDeployments
+          - TestAcc_ResourceClusterAzureWithDedicatedDeployments
+          - TestAcc_ResourceClusterGcpWithDedicatedDeployments
+          - TestAcc_ResourceClusterRemovedOutsideOfTerraform
+          - TestAcc_ResourceClusterAwsWithDr
+          - TestAcc_ResourceClusterGcpWithDr
+          - TestAcc_ResourceClusterAzureWithDr
+          - TestAcc_ResourceClusterAzureEnableDrOnExistingCluster
+          - TestAcc_ResourceClusterDrValidation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
+        with:
+          terraform_version: latest
+          terraform_wrapper: false
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          HYBRID_ORGANIZATION_API_TOKEN: ${{ secrets.STAGE_HYBRID_ORGANIZATION_API_TOKEN }}
+          HYBRID_ORGANIZATION_ID: clx46ca4y061z01jleyku7sr6
+          HOSTED_ORGANIZATION_API_TOKEN: ${{ secrets.STAGE_HOSTED_ORGANIZATION_API_TOKEN }}
+          HOSTED_ORGANIZATION_ID: clx46acvv060e01ilddqlbsmc
+          HOSTED_SCIM_ORGANIZATION_API_TOKEN: ${{ secrets.STAGE_HOSTED_SCIM_ORGANIZATION_API_TOKEN }}
+          HOSTED_SCIM_ORGANIZATION_ID: clz3blqb500lh01mtkwu9zk5z
+          HYBRID_CLUSTER_ID: cmfn55kzv0x0401mps8d3pw3e
+          HYBRID_DRY_RUN_CLUSTER_ID: cmfn54h0k0vuf01mp52kkfu6d
+          HYBRID_NODE_POOL_ID: cmfn55kzv0x0301mppsx7hwb6
+          ASTRO_API_HOST: https://api.astronomer-stage.io
+          HOSTED_TEAM_ID: clx486hno068301il306nuhsm
+          HOSTED_USER_ID: clz3a95hw00j301jj5jfmcgwd
+          HOSTED_DUMMY_USER_ID: clzawlsb701vv01ikvsqz5mws
+          HOSTED_DEPLOYMENT_ID: cmmf9dpfu15iv01dw00xbakrg
+          HOSTED_DEPLOYMENT_API_TOKEN: ${{ secrets.STAGE_HOSTED_DEPLOYMENT_API_TOKEN }}
+          HOSTED_STANDARD_DEPLOYMENT_ID: cm077ee2807g301kpjkqdoc15
+          HOSTED_WORKSPACE_ID: clx480rvx068u01j9mp7t7fqh
+          HOSTED_API_TOKEN_ID: clxm46ged05b301neuucdqwox
+          HOSTED_ALERT_ID: cmmf9prtm15ya01dww674fosf
+          HOSTED_NOTIFICATION_CHANNEL_ID: cmbr12fik1m7l01gpln1bgtbb
+          HOSTED_DEDICATED_CLUSTER_ID: cm73vsinm07hy01pu4dq1rei2
+          HOSTED_CUSTOM_ROLE_ID: cmk64yvat027n01q7f9gn5ghg
+          REMOTE_EXECUTION_DEPLOYMENT_ID: cmng0suky152501ilj9cjlmz3
+        run: go test ./internal/provider/resources/... -v -run "^${{ matrix.cluster_test }}$" -timeout 100m
 
   testacc-stage:
     # This job runs every Monday.
@@ -212,7 +300,7 @@ jobs:
           HOSTED_DEDICATED_CLUSTER_ID: cm73vsinm07hy01pu4dq1rei2
           HOSTED_CUSTOM_ROLE_ID: cmk64yvat027n01q7f9gn5ghg
           REMOTE_EXECUTION_DEPLOYMENT_ID: cmng0suky152501ilj9cjlmz3
-          TESTARGS: "-failfast"
+          TESTARGS: "-failfast -parallel 9"
         run: make testacc
 
   testacc-dev:
@@ -279,5 +367,5 @@ jobs:
           HOSTED_DEDICATED_CLUSTER_ID: cm1zjsqu008ab01phlcna8swg
           HOSTED_CUSTOM_ROLE_ID: clzlwgj6h001c01hi3gqlk66p
           REMOTE_EXECUTION_DEPLOYMENT_ID: cmng0v65a00xl01ou62ko7836
-          TESTARGS: "-failfast"
+          TESTARGS: "-failfast -parallel 9"
         run: make testacc

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -12,6 +12,10 @@ on:
   schedule:
     - cron: '30 21 * * 1'  # Runs every Monday at 2:30PST for stage environment
     - cron: '30 21 * * 2,5'  # Runs every Tuesday and Friday at 2:30PST for dev environment
+  # Manual trigger for testing workflow changes on a branch before merging to main.
+  # Always runs the cluster tests (skips the diff-based check, which only makes sense
+  # relative to a PR base).
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -64,7 +68,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      github.event_name == 'pull_request_target'
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -77,25 +82,30 @@ jobs:
       - name: Determine if expensive cluster tests should run
         id: check
         run: |
-         git fetch --all
-         echo "CHECKING FILES FOR SKIP LOGIC..."
-         SKIP_TESTS="True"
-         FILES_TO_CHECK=(
-           "internal/provider/schemas/deployment.go"
-           "internal/provider/schemas/cluster.go"
-           "internal/provider/models/deployment.go"
-           "internal/provider/models/cluster.go"
-           "internal/provider/resources/resource_cluster.go"
-           "internal/provider/resources/resource_cluster_test.go"
-           "internal/provider/resources/resource_deployment.go"
-           "internal/provider/resources/common_cluster.go"
-         )
-         for file in "${FILES_TO_CHECK[@]}"; do
-           if git diff --name-only origin/${{ github.event.pull_request.base.ref || github.ref_name }} ${{ github.event.pull_request.head.sha || github.sha }} | grep -q "$file"; then
-             SKIP_TESTS="False"
-             break
-           fi
-         done
+         if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+           echo "Manual trigger: running cluster tests unconditionally."
+           SKIP_TESTS="False"
+         else
+           git fetch --all
+           echo "CHECKING FILES FOR SKIP LOGIC..."
+           SKIP_TESTS="True"
+           FILES_TO_CHECK=(
+             "internal/provider/schemas/deployment.go"
+             "internal/provider/schemas/cluster.go"
+             "internal/provider/models/deployment.go"
+             "internal/provider/models/cluster.go"
+             "internal/provider/resources/resource_cluster.go"
+             "internal/provider/resources/resource_cluster_test.go"
+             "internal/provider/resources/resource_deployment.go"
+             "internal/provider/resources/common_cluster.go"
+           )
+           for file in "${FILES_TO_CHECK[@]}"; do
+             if git diff --name-only origin/${{ github.event.pull_request.base.ref || github.ref_name }} ${{ github.event.pull_request.head.sha || github.sha }} | grep -q "$file"; then
+               SKIP_TESTS="False"
+               break
+             fi
+           done
+         fi
          echo "SKIP_CLUSTER_RESOURCE_TESTS=$SKIP_TESTS"
          echo "skip=$SKIP_TESTS" >> "$GITHUB_OUTPUT"
 
@@ -105,7 +115,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      github.event_name == 'pull_request_target'
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'workflow_dispatch'
     timeout-minutes: 60 # cluster resource tests run separately in testacc-cluster
     strategy:
       fail-fast: true

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -41,7 +41,7 @@ output "cluster" {
 - `dr_service_peering_range` (String) The disaster recovery service peering range (GCP Only).
 - `dr_service_subnet_range` (String) The disaster recovery service subnet range (GCP Only).
 - `dr_vpc_subnet_range` (String) The VPC subnet range for the Disaster Recovery region
-- `enable_replication_time_control` (Boolean) Whether S3 Replication Time Control is enabled for Disaster Recovery (AWS only)
+- `enable_replication_time_control` (Boolean) Whether Replication Time Control is enabled for Disaster Recovery task log replication
 - `health_status` (Attributes) Cluster health status (see [below for nested schema](#nestedatt--health_status))
 - `is_dr_enabled` (Boolean) Whether Disaster Recovery is enabled on the cluster
 - `is_failed_over` (Boolean) Whether the cluster is currently failed over to the DR region

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -59,7 +59,7 @@ Read-Only:
 - `dr_service_peering_range` (String) The disaster recovery service peering range (GCP Only).
 - `dr_service_subnet_range` (String) The disaster recovery service subnet range (GCP Only).
 - `dr_vpc_subnet_range` (String) The VPC subnet range for the Disaster Recovery region
-- `enable_replication_time_control` (Boolean) Whether S3 Replication Time Control is enabled for Disaster Recovery (AWS only)
+- `enable_replication_time_control` (Boolean) Whether Replication Time Control is enabled for Disaster Recovery task log replication
 - `health_status` (Attributes) Cluster health status (see [below for nested schema](#nestedatt--clusters--health_status))
 - `is_dr_enabled` (Boolean) Whether Disaster Recovery is enabled on the cluster
 - `is_failed_over` (Boolean) Whether the cluster is currently failed over to the DR region

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -37,6 +37,21 @@ resource "astro_cluster" "azure_example" {
   workspace_ids    = ["clv4wcf6f003u01m3zp7gsvzg"]
 }
 
+resource "astro_cluster" "azure_dr_example" {
+  type                = "DEDICATED"
+  name                = "my dr-enabled azure cluster"
+  region              = "westus2"
+  cloud_provider      = "AZURE"
+  vpc_subnet_range    = "172.20.0.0/20"
+  workspace_ids       = []
+  is_dr_enabled       = true
+  dr_region           = "eastus2"
+  dr_vpc_subnet_range = "172.21.0.0/20"
+  # enable_replication_time_control is unset here: the provider will send true only if
+  # region and dr_region are on the same continent (americas, in this example), and
+  # otherwise leaves it disabled. You may always explicitly set this to false.
+}
+
 resource "astro_cluster" "aws_dr_example" {
   type                = "DEDICATED"
   name                = "my dr-enabled cluster"
@@ -117,8 +132,8 @@ resource "astro_cluster" "imported_cluster" {
 - `dr_service_peering_range` (String) The disaster recovery service peering range (GCP Only).
 - `dr_service_subnet_range` (String) The disaster recovery service subnet range (GCP Only).
 - `dr_vpc_subnet_range` (String) The VPC subnet range for the Disaster Recovery region. Only valid when `is_dr_enabled` is true. Cannot be changed once set.
-- `enable_replication_time_control` (Boolean) Whether to enable S3 Replication Time Control for Disaster Recovery. Only valid when `is_dr_enabled` is true (AWS only).
-- `is_dr_enabled` (Boolean) Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.
+- `enable_replication_time_control` (Boolean) Whether to enable Replication Time Control for Disaster Recovery task log replication. Only valid when `is_dr_enabled` is true. For `AZURE` clusters: if left unset, this is automatically enabled when `region` and `dr_region` are on the same continent, and left disabled otherwise. Explicitly setting this to `true` when `region` and `dr_region` are on different continents will fail at plan time. You may always explicitly set this to `false`, regardless of the region pair.
+- `is_dr_enabled` (Boolean) Whether Disaster Recovery is enabled on the cluster. Supported for `AWS`, `GCP`, and `AZURE` clusters. For `AWS` and `GCP`, DR can only be enabled at cluster creation time; enabling DR on an existing `AWS` or `GCP` cluster requires the admin API. For `AZURE`, DR can be enabled or disabled on an existing cluster via this resource. Can be set to `false` to disable DR on an existing cluster for any provider.
 - `is_failed_over` (Boolean) Whether the cluster is currently failed over to the DR region. Set to `true` to trigger failover; set to `false` to fail back.
 - `pod_subnet_range` (String) Cluster pod subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
 - `secondary_vpc_cidr` (String) Secondary CIDR for pod networking (AWS only, /16 to /20). Cannot be changed once set.

--- a/examples/resources/astro_cluster/resource.tf
+++ b/examples/resources/astro_cluster/resource.tf
@@ -22,6 +22,21 @@ resource "astro_cluster" "azure_example" {
   workspace_ids    = ["clv4wcf6f003u01m3zp7gsvzg"]
 }
 
+resource "astro_cluster" "azure_dr_example" {
+  type                = "DEDICATED"
+  name                = "my dr-enabled azure cluster"
+  region              = "westus2"
+  cloud_provider      = "AZURE"
+  vpc_subnet_range    = "172.20.0.0/20"
+  workspace_ids       = []
+  is_dr_enabled       = true
+  dr_region           = "eastus2"
+  dr_vpc_subnet_range = "172.21.0.0/20"
+  # enable_replication_time_control is unset here: the provider will send true only if
+  # region and dr_region are on the same continent (americas, in this example), and
+  # otherwise leaves it disabled. You may always explicitly set this to false.
+}
+
 resource "astro_cluster" "aws_dr_example" {
   type                = "DEDICATED"
   name                = "my dr-enabled cluster"

--- a/internal/provider/resources/azure_region_locations.go
+++ b/internal/provider/resources/azure_region_locations.go
@@ -1,0 +1,43 @@
+package resources
+
+import "strings"
+
+// azureRegionContinents maps Azure region names to their continent ("location" in
+// stagehand's terms). This mirrors the `location` values for the `azure` provider
+// under the `HOSTED` clusterType in apps/stagehand/pkg/assets/provider-specs.yaml,
+// which is what backs apps/core's ValidateEnableReplicationTimeControl (used to
+// validate that a Replication Time Control-enabled DR cluster's region and dr_region
+// are on the same continent). Keep this in sync if Azure regions are added/changed
+// there.
+var azureRegionContinents = map[string]string{
+	"eastus2":            "americas",
+	"eastus":             "americas",
+	"northeurope":        "europe",
+	"australiaeast":      "asiapacific",
+	"westeurope":         "europe",
+	"westus2":            "americas",
+	"japaneast":          "asiapacific",
+	"canadacentral":      "americas",
+	"uksouth":            "europe",
+	"brazilsouth":        "americas",
+	"centralindia":       "asiapacific",
+	"francecentral":      "europe",
+	"centralus":          "americas",
+	"westus3":            "americas",
+	"southcentralus":     "americas",
+	"uaenorth":           "middleeast",
+	"germanywestcentral": "europe",
+	"southafricanorth":   "africa",
+}
+
+// azureRegionContinent returns the continent for an Azure region name, matched
+// case-insensitively (mirroring stagehand.GetRegionLocations), and whether the
+// region was recognized.
+func azureRegionContinent(region string) (string, bool) {
+	for name, continent := range azureRegionContinents {
+		if strings.EqualFold(name, region) {
+			return continent, true
+		}
+	}
+	return "", false
+}

--- a/internal/provider/resources/azure_region_locations_test.go
+++ b/internal/provider/resources/azure_region_locations_test.go
@@ -249,6 +249,12 @@ func TestAzureEffectiveEnableReplicationTimeControl_UnknownValuesDeferred(t *tes
 	}
 	assert.Nil(t, azureEffectiveEnableReplicationTimeControl(data))
 
+	// enable_replication_time_control itself unknown: this is the normal plan-time
+	// state for "left unset" on an Optional+Computed attribute with no plan
+	// modifiers (Create, or Update with no prior explicit value) - it must be
+	// treated the same as unset-and-null and computed from the region pair, not
+	// deferred. Region/dr_region are on the same continent here, so this computes
+	// to true.
 	dataUnknownRTC := &models.ClusterResource{
 		CloudProvider:                types.StringValue("AZURE"),
 		Region:                       types.StringValue("eastus2"),
@@ -256,7 +262,10 @@ func TestAzureEffectiveEnableReplicationTimeControl_UnknownValuesDeferred(t *tes
 		DrRegion:                     types.StringValue("westus2"),
 		EnableReplicationTimeControl: types.BoolUnknown(),
 	}
-	assert.Nil(t, azureEffectiveEnableReplicationTimeControl(dataUnknownRTC))
+	got := azureEffectiveEnableReplicationTimeControl(dataUnknownRTC)
+	if assert.NotNil(t, got) {
+		assert.True(t, *got)
+	}
 }
 
 func TestValidateAzureConfig_ReplicationTimeControlSkipsUnknownValues(t *testing.T) {

--- a/internal/provider/resources/azure_region_locations_test.go
+++ b/internal/provider/resources/azure_region_locations_test.go
@@ -1,0 +1,279 @@
+package resources
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAzureRegionContinent(t *testing.T) {
+	tests := []struct {
+		name          string
+		region        string
+		wantContinent string
+		wantOk        bool
+	}{
+		{"known region", "eastus2", "americas", true},
+		{"another continent", "westeurope", "europe", true},
+		{"case insensitive", "EastUS2", "americas", true},
+		{"mixed case", "WestEurope", "europe", true},
+		{"unknown region", "notarealregion", "", false},
+		{"empty region", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			continent, ok := azureRegionContinent(tt.region)
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantContinent, continent)
+		})
+	}
+}
+
+// azureClusterResourceData builds a minimal models.ClusterResource for exercising
+// validateAzureConfig's Replication Time Control region-pair check in isolation.
+func azureClusterResourceData(region, drRegion string, isDrEnabled bool, enableRTC *bool) *models.ClusterResource {
+	data := &models.ClusterResource{
+		CloudProvider: types.StringValue("AZURE"),
+		Region:        types.StringValue(region),
+		IsDrEnabled:   types.BoolValue(isDrEnabled),
+	}
+	if drRegion == "" {
+		data.DrRegion = types.StringNull()
+	} else {
+		data.DrRegion = types.StringValue(drRegion)
+	}
+	if enableRTC == nil {
+		data.EnableReplicationTimeControl = types.BoolNull()
+	} else {
+		data.EnableReplicationTimeControl = types.BoolValue(*enableRTC)
+	}
+	return data
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestValidateAzureConfig_ReplicationTimeControlRegionPair(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		region      string
+		drRegion    string
+		enableRTC   *bool
+		expectError string // substring expected in a diagnostic summary; empty means no error
+	}{
+		{
+			name:      "same continent, RTC explicitly true",
+			region:    "eastus2",
+			drRegion:  "westus2",
+			enableRTC: boolPtr(true),
+		},
+		{
+			name:      "same continent, RTC unset",
+			region:    "eastus2",
+			drRegion:  "westus2",
+			enableRTC: nil,
+		},
+		{
+			name:        "different continent, RTC explicitly true",
+			region:      "eastus2",
+			drRegion:    "westeurope",
+			enableRTC:   boolPtr(true),
+			expectError: "Replication time control requires regions on the same continent",
+		},
+		{
+			// Left unset, the provider simply won't send true (see
+			// TestAzureEffectiveEnableReplicationTimeControl) - no error needed.
+			name:      "different continent, RTC unset",
+			region:    "eastus2",
+			drRegion:  "westeurope",
+			enableRTC: nil,
+		},
+		{
+			name:      "different continent, RTC explicitly false opts out",
+			region:    "eastus2",
+			drRegion:  "westeurope",
+			enableRTC: boolPtr(false),
+		},
+		{
+			name:        "unrecognized primary region, RTC explicitly true",
+			region:      "notarealregion",
+			drRegion:    "westus2",
+			enableRTC:   boolPtr(true),
+			expectError: "has no defined location",
+		},
+		{
+			name:        "unrecognized dr_region, RTC explicitly true",
+			region:      "eastus2",
+			drRegion:    "notarealregion",
+			enableRTC:   boolPtr(true),
+			expectError: "has no defined location",
+		},
+		{
+			// Left unset, an unrecognized region just means the provider can't
+			// compute a default - it isn't a validation error.
+			name:      "unrecognized primary region, RTC unset",
+			region:    "notarealregion",
+			drRegion:  "westus2",
+			enableRTC: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := azureClusterResourceData(tt.region, tt.drRegion, true, tt.enableRTC)
+			diags := validateAzureConfig(ctx, data)
+
+			if tt.expectError == "" {
+				assert.False(t, diags.HasError(), "expected no error, got: %v", diags)
+				return
+			}
+
+			assert.True(t, diags.HasError(), "expected an error")
+			found := false
+			for _, d := range diags {
+				if strings.Contains(d.Summary(), tt.expectError) {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected a diagnostic with summary containing %q, got: %v", tt.expectError, diags)
+		})
+	}
+}
+
+func TestValidateAzureConfig_ReplicationTimeControlSkipsWhenDrDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	// DR disabled: region-pair validation should not run at all (a different
+	// diagnostic - "enable_replication_time_control is only valid..." - fires
+	// instead, since RTC is only meaningful when DR is enabled).
+	data := azureClusterResourceData("eastus2", "westeurope", false, boolPtr(true))
+	diags := validateAzureConfig(ctx, data)
+
+	assert.True(t, diags.HasError())
+	for _, d := range diags {
+		assert.NotEqual(t, "Replication time control requires regions on the same continent", d.Summary())
+	}
+}
+
+func TestAzureEffectiveEnableReplicationTimeControl(t *testing.T) {
+	tests := []struct {
+		name      string
+		region    string
+		drRegion  string
+		enableRTC *bool
+		want      *bool
+	}{
+		{
+			name:      "unset, same continent -> computed true",
+			region:    "eastus2",
+			drRegion:  "westus2",
+			enableRTC: nil,
+			want:      boolPtr(true),
+		},
+		{
+			name:      "unset, different continent -> nothing sent",
+			region:    "eastus2",
+			drRegion:  "westeurope",
+			enableRTC: nil,
+			want:      nil,
+		},
+		{
+			name:      "unset, unrecognized region -> nothing sent",
+			region:    "notarealregion",
+			drRegion:  "westus2",
+			enableRTC: nil,
+			want:      nil,
+		},
+		{
+			name:      "explicit true, same continent -> passed through",
+			region:    "eastus2",
+			drRegion:  "westus2",
+			enableRTC: boolPtr(true),
+			want:      boolPtr(true),
+		},
+		{
+			name: "explicit true, different continent -> passed through unchanged",
+			// validateAzureConfig is what rejects this combination; this function
+			// just forwards the user's explicit choice.
+			region:    "eastus2",
+			drRegion:  "westeurope",
+			enableRTC: boolPtr(true),
+			want:      boolPtr(true),
+		},
+		{
+			name:      "explicit false, same continent -> passed through",
+			region:    "eastus2",
+			drRegion:  "westus2",
+			enableRTC: boolPtr(false),
+			want:      boolPtr(false),
+		},
+		{
+			name:      "explicit false, different continent -> passed through",
+			region:    "eastus2",
+			drRegion:  "westeurope",
+			enableRTC: boolPtr(false),
+			want:      boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := azureClusterResourceData(tt.region, tt.drRegion, true, tt.enableRTC)
+			got := azureEffectiveEnableReplicationTimeControl(data)
+
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func TestAzureEffectiveEnableReplicationTimeControl_UnknownValuesDeferred(t *testing.T) {
+	// dr_region derived from an unknown value (e.g. another resource's attribute):
+	// the provider can't compute a default, so it must not guess - send nothing.
+	data := &models.ClusterResource{
+		CloudProvider: types.StringValue("AZURE"),
+		Region:        types.StringValue("eastus2"),
+		IsDrEnabled:   types.BoolValue(true),
+		DrRegion:      types.StringUnknown(),
+	}
+	assert.Nil(t, azureEffectiveEnableReplicationTimeControl(data))
+
+	dataUnknownRTC := &models.ClusterResource{
+		CloudProvider:                types.StringValue("AZURE"),
+		Region:                       types.StringValue("eastus2"),
+		IsDrEnabled:                  types.BoolValue(true),
+		DrRegion:                     types.StringValue("westus2"),
+		EnableReplicationTimeControl: types.BoolUnknown(),
+	}
+	assert.Nil(t, azureEffectiveEnableReplicationTimeControl(dataUnknownRTC))
+}
+
+func TestValidateAzureConfig_ReplicationTimeControlSkipsUnknownValues(t *testing.T) {
+	ctx := context.Background()
+
+	// dr_region derived from an unknown value (e.g. another resource's attribute)
+	// must not trigger a false-positive continent mismatch at plan time.
+	data := &models.ClusterResource{
+		CloudProvider:                types.StringValue("AZURE"),
+		Region:                       types.StringValue("eastus2"),
+		IsDrEnabled:                  types.BoolValue(true),
+		DrRegion:                     types.StringUnknown(),
+		EnableReplicationTimeControl: types.BoolValue(true),
+	}
+	diags := validateAzureConfig(ctx, data)
+
+	for _, d := range diags {
+		assert.NotEqual(t, "Replication time control requires regions on the same continent", d.Summary())
+	}
+}

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -127,14 +127,17 @@ func (r *ClusterResource) Create(
 		}
 	case platform.ClusterCloudProviderAZURE:
 		createAzureDedicatedClusterRequest := platform.CreateAzureClusterRequest{
-			CloudProvider:   platform.CreateAzureClusterRequestCloudProvider(data.CloudProvider.ValueString()),
-			Name:            data.Name.ValueString(),
-			NodePools:       nil,
-			ProviderAccount: data.ProviderAccount.ValueStringPointer(),
-			Region:          data.Region.ValueString(),
-			TenantId:        data.TenantId.ValueStringPointer(),
-			Type:            platform.CreateAzureClusterRequestType(data.Type.ValueString()),
-			VpcSubnetRange:  data.VpcSubnetRange.ValueString(),
+			CloudProvider:                platform.CreateAzureClusterRequestCloudProvider(data.CloudProvider.ValueString()),
+			Name:                         data.Name.ValueString(),
+			NodePools:                    nil,
+			ProviderAccount:              data.ProviderAccount.ValueStringPointer(),
+			Region:                       data.Region.ValueString(),
+			TenantId:                     data.TenantId.ValueStringPointer(),
+			Type:                         platform.CreateAzureClusterRequestType(data.Type.ValueString()),
+			VpcSubnetRange:               data.VpcSubnetRange.ValueString(),
+			DrRegion:                     data.DrRegion.ValueStringPointer(),
+			DrVpcSubnetRange:             data.DrVpcSubnetRange.ValueStringPointer(),
+			EnableReplicationTimeControl: azureEffectiveEnableReplicationTimeControl(&data),
 		}
 
 		// workspaceIds
@@ -328,6 +331,16 @@ func (r *ClusterResource) Update(
 	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.IsUnknown() && !data.IsDrEnabled.ValueBool() {
 		enableDr := false
 		updateDedicatedClusterRequest.EnableDr = &enableDr
+	}
+	// Unlike AWS and GCP, Azure has no replication-lag phase, so DR can be enabled
+	// on an existing cluster in a single update request.
+	if platform.ClusterCloudProvider(data.CloudProvider.ValueString()) == platform.ClusterCloudProviderAZURE &&
+		!data.IsDrEnabled.IsNull() && !data.IsDrEnabled.IsUnknown() && data.IsDrEnabled.ValueBool() {
+		enableDr := true
+		updateDedicatedClusterRequest.EnableDr = &enableDr
+		updateDedicatedClusterRequest.DrRegion = data.DrRegion.ValueStringPointer()
+		updateDedicatedClusterRequest.DrVpcSubnetRange = data.DrVpcSubnetRange.ValueStringPointer()
+		updateDedicatedClusterRequest.EnableReplicationTimeControl = azureEffectiveEnableReplicationTimeControl(&data)
 	}
 	// Set IsFailedOver if specified (must be an explicit value, not null or unknown)
 	if !data.IsFailedOver.IsNull() && !data.IsFailedOver.IsUnknown() {
@@ -634,31 +647,11 @@ func validateAzureConfig(ctx context.Context, data *models.ClusterResource) diag
 		)
 	}
 
-	// secondary_vpc_cidr is AWS only
+	// secondary_vpc_cidr / dr_secondary_vpc_cidr are AWS only
 	if !data.SecondaryVpcCidr.IsNull() {
 		diags.AddError(
 			"secondary_vpc_cidr is not allowed for 'AZURE' cluster",
 			"Please remove secondary_vpc_cidr",
-		)
-	}
-
-	// DR is not supported for Azure clusters
-	if !data.IsDrEnabled.IsNull() && data.IsDrEnabled.ValueBool() {
-		diags.AddError(
-			"Disaster Recovery is not supported for 'AZURE' clusters",
-			"Please remove is_dr_enabled, dr_region, dr_vpc_subnet_range, and dr_secondary_vpc_cidr",
-		)
-	}
-	if !data.DrRegion.IsNull() {
-		diags.AddError(
-			"dr_region is not allowed for 'AZURE' cluster",
-			"Please remove dr_region",
-		)
-	}
-	if !data.DrVpcSubnetRange.IsNull() {
-		diags.AddError(
-			"dr_vpc_subnet_range is not allowed for 'AZURE' cluster",
-			"Please remove dr_vpc_subnet_range",
 		)
 	}
 	if !data.DrSecondaryVpcCidr.IsNull() {
@@ -667,12 +660,8 @@ func validateAzureConfig(ctx context.Context, data *models.ClusterResource) diag
 			"Please remove dr_secondary_vpc_cidr",
 		)
 	}
-	if !data.EnableReplicationTimeControl.IsNull() {
-		diags.AddError(
-			"enable_replication_time_control is not allowed for 'AZURE' cluster",
-			"Please remove enable_replication_time_control",
-		)
-	}
+
+	// dr_pod_subnet_range, dr_service_peering_range, dr_service_subnet_range are GCP only
 	if !data.DrPodSubnetRange.IsNull() {
 		diags.AddError(
 			"dr_pod_subnet_range is not allowed for 'AZURE' cluster",
@@ -692,7 +681,123 @@ func validateAzureConfig(ctx context.Context, data *models.ClusterResource) diag
 		)
 	}
 
+	// DR validation
+	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.IsUnknown() && data.IsDrEnabled.ValueBool() {
+		if data.DrRegion.IsNull() {
+			diags.AddError(
+				"dr_region is required when is_dr_enabled is true",
+				"Please set dr_region to the secondary region for Disaster Recovery",
+			)
+		}
+		diags.Append(validateAzureReplicationTimeControlRegionPair(data)...)
+	}
+	if !data.IsDrEnabled.IsNull() && !data.IsDrEnabled.ValueBool() {
+		if !data.DrVpcSubnetRange.IsNull() {
+			diags.AddError(
+				"dr_vpc_subnet_range is only valid when is_dr_enabled is true",
+				"Please remove dr_vpc_subnet_range or set is_dr_enabled to true",
+			)
+		}
+		if !data.EnableReplicationTimeControl.IsNull() {
+			diags.AddError(
+				"enable_replication_time_control is only valid when is_dr_enabled is true",
+				"Please remove enable_replication_time_control or set is_dr_enabled to true",
+			)
+		}
+	}
+
 	return diags
+}
+
+// validateAzureReplicationTimeControlRegionPair mirrors apps/core's
+// ValidateEnableReplicationTimeControl: Replication Time Control requires the
+// cluster's primary region and dr_region to be on the same continent. This runs
+// client-side (using the same region/continent data as the backend's provider
+// spec) so an invalid region pair is rejected at plan time instead of only
+// surfacing as an apply-time API error.
+//
+// The user may always explicitly set this to `false`, regardless of the region
+// pair. A left-unset value is not validated here at all: the provider computes
+// a safe value itself (see azureEffectiveEnableReplicationTimeControl) instead
+// of requiring the user to pick a compatible region pair up front.
+func validateAzureReplicationTimeControlRegionPair(data *models.ClusterResource) diag.Diagnostics {
+	diags := make(diag.Diagnostics, 0)
+
+	if data.EnableReplicationTimeControl.IsUnknown() || data.EnableReplicationTimeControl.IsNull() {
+		return diags
+	}
+	if !data.EnableReplicationTimeControl.ValueBool() {
+		// Explicitly opted out of Replication Time Control - always allowed.
+		return diags
+	}
+	if data.Region.IsUnknown() || data.DrRegion.IsNull() || data.DrRegion.IsUnknown() {
+		// Region values aren't known yet (e.g. derived from another resource); defer to apply-time validation.
+		return diags
+	}
+
+	region := data.Region.ValueString()
+	drRegion := data.DrRegion.ValueString()
+
+	regionContinent, regionOk := azureRegionContinent(region)
+	if !regionOk {
+		diags.AddError(
+			fmt.Sprintf("Region %s has no defined location", region),
+			"Please use a supported Azure region, or set enable_replication_time_control to false.",
+		)
+		return diags
+	}
+	drRegionContinent, drRegionOk := azureRegionContinent(drRegion)
+	if !drRegionOk {
+		diags.AddError(
+			fmt.Sprintf("Region %s has no defined location", drRegion),
+			"Please use a supported Azure region, or set enable_replication_time_control to false.",
+		)
+		return diags
+	}
+
+	if regionContinent != drRegionContinent {
+		diags.AddError(
+			"Replication time control requires regions on the same continent",
+			"enable_replication_time_control cannot be set to true for this region pair. Set it explicitly to false, or choose a dr_region on the same continent as region.",
+		)
+	}
+
+	return diags
+}
+
+// azureEffectiveEnableReplicationTimeControl determines the value to send to the
+// API for enable_replication_time_control on an Azure cluster.
+//
+// If the user set the value explicitly, it is sent as-is (validateAzureConfig
+// already ensures an explicit `true` is only allowed when region and dr_region
+// share a continent; `false` is always allowed). If the user left it unset, the
+// API no longer defaults this to a region-aware value, so the provider computes
+// one: `true` only when region and dr_region are on the same continent,
+// otherwise nothing is sent (leaving the field, and Replication Time Control,
+// off).
+func azureEffectiveEnableReplicationTimeControl(data *models.ClusterResource) *bool {
+	if data.EnableReplicationTimeControl.IsUnknown() {
+		return nil
+	}
+	if !data.EnableReplicationTimeControl.IsNull() {
+		return data.EnableReplicationTimeControl.ValueBoolPointer()
+	}
+
+	if data.Region.IsUnknown() || data.DrRegion.IsNull() || data.DrRegion.IsUnknown() {
+		return nil
+	}
+
+	regionContinent, regionOk := azureRegionContinent(data.Region.ValueString())
+	if !regionOk {
+		return nil
+	}
+	drRegionContinent, drRegionOk := azureRegionContinent(data.DrRegion.ValueString())
+	if !drRegionOk || regionContinent != drRegionContinent {
+		return nil
+	}
+
+	enable := true
+	return &enable
 }
 
 func validateGcpConfig(ctx context.Context, data *models.ClusterResource) diag.Diagnostics {

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -775,11 +775,16 @@ func validateAzureReplicationTimeControlRegionPair(data *models.ClusterResource)
 // one: `true` only when region and dr_region are on the same continent,
 // otherwise nothing is sent (leaving the field, and Replication Time Control,
 // off).
+//
+// data is populated from the plan (req.Plan.Get), not the config. This attribute
+// is Optional+Computed with no plan modifiers, so when the user leaves it unset,
+// the framework's default "proposed new state" logic plans it as Unknown, not
+// Null — Null is really only ever seen here if it's read from config elsewhere.
+// Both must be treated as "not explicitly set": bailing out only on Unknown (as
+// this used to) skips the compute-from-continent logic below on every Create,
+// since that IS the unset case at plan time.
 func azureEffectiveEnableReplicationTimeControl(data *models.ClusterResource) *bool {
-	if data.EnableReplicationTimeControl.IsUnknown() {
-		return nil
-	}
-	if !data.EnableReplicationTimeControl.IsNull() {
+	if !data.EnableReplicationTimeControl.IsNull() && !data.EnableReplicationTimeControl.IsUnknown() {
 		return data.EnableReplicationTimeControl.ValueBoolPointer()
 	}
 

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -609,6 +609,127 @@ func TestAcc_ResourceClusterGcpWithDr(t *testing.T) {
 	})
 }
 
+func TestAcc_ResourceClusterAzureWithDr(t *testing.T) {
+	if os.Getenv(SKIP_CLUSTER_RESOURCE_TESTS) == "True" {
+		t.Skip(SKIP_CLUSTER_RESOURCE_TESTS_REASON)
+	}
+	namePrefix := utils.GenerateTestResourceName(10)
+
+	azureClusterName := fmt.Sprintf("%v_azure_dr", namePrefix)
+	azureResourceVar := fmt.Sprintf("astro_cluster.%v", azureClusterName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
+		CheckDestroy:             testAccCheckClusterExistence(t, azureClusterName, true, false),
+		Steps: []resource.TestStep{
+			// Create Azure cluster with DR enabled at creation time
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					cluster(clusterInput{
+						Name:          azureClusterName,
+						Region:        "westus2",
+						CloudProvider: "AZURE",
+						IsDrEnabled:   true,
+						DrRegion:      "eastus2",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(azureResourceVar, "name", azureClusterName),
+					resource.TestCheckResourceAttr(azureResourceVar, "region", "westus2"),
+					resource.TestCheckResourceAttr(azureResourceVar, "cloud_provider", "AZURE"),
+					resource.TestCheckResourceAttrSet(azureResourceVar, "vpc_subnet_range"),
+					// Check DR fields
+					resource.TestCheckResourceAttr(azureResourceVar, "is_dr_enabled", "true"),
+					resource.TestCheckResourceAttr(azureResourceVar, "dr_region", "eastus2"),
+					resource.TestCheckResourceAttrSet(azureResourceVar, "is_failed_over"),
+					resource.TestCheckResourceAttr(azureResourceVar, "enable_replication_time_control", "true"),
+
+					testAccCheckClusterExistence(t, azureClusterName, true, true),
+				),
+			},
+			// Import existing DR cluster
+			{
+				PreConfig:               func() { waitForClusterStableState(t, azureClusterName) },
+				ResourceName:            azureResourceVar,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"health_status", "health_status.value", "status"},
+			},
+		},
+	})
+}
+
+// TestAcc_ResourceClusterAzureEnableDrOnExistingCluster verifies the Azure-specific
+// behavior called out in SQDPREL-275: unlike AWS and GCP, DR can be enabled (and
+// disabled) on an existing Azure cluster via a single update, with no separate
+// replication-lag phase required.
+func TestAcc_ResourceClusterAzureEnableDrOnExistingCluster(t *testing.T) {
+	if os.Getenv(SKIP_CLUSTER_RESOURCE_TESTS) == "True" {
+		t.Skip(SKIP_CLUSTER_RESOURCE_TESTS_REASON)
+	}
+	namePrefix := utils.GenerateTestResourceName(10)
+
+	azureClusterName := fmt.Sprintf("%v_azure_dr_update", namePrefix)
+	azureResourceVar := fmt.Sprintf("astro_cluster.%v", azureClusterName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
+		CheckDestroy:             testAccCheckClusterExistence(t, azureClusterName, true, false),
+		Steps: []resource.TestStep{
+			// Create Azure cluster without DR
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					cluster(clusterInput{
+						Name:          azureClusterName,
+						Region:        "westus2",
+						CloudProvider: "AZURE",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(azureResourceVar, "is_dr_enabled", "false"),
+					testAccCheckClusterExistence(t, azureClusterName, true, true),
+				),
+			},
+			// Enable DR on the existing cluster via update
+			{
+				PreConfig: func() { waitForClusterStableState(t, azureClusterName) },
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
+					cluster(clusterInput{
+						Name:          azureClusterName,
+						Region:        "westus2",
+						CloudProvider: "AZURE",
+						IsDrEnabled:   true,
+						DrRegion:      "eastus2",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(azureResourceVar, "is_dr_enabled", "true"),
+					resource.TestCheckResourceAttr(azureResourceVar, "dr_region", "eastus2"),
+				),
+			},
+			// Disable DR on the existing cluster via update
+			// (the cluster() helper omits is_dr_enabled entirely when false, so this
+			// step needs an explicit `is_dr_enabled = false` to exercise the disable path)
+			{
+				PreConfig: func() { waitForClusterStableState(t, azureClusterName) },
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "westus2"
+	cloud_provider = "AZURE"
+	vpc_subnet_range = "172.20.0.0/20"
+	is_dr_enabled = false
+	workspace_ids = []
+}
+`, azureClusterName, azureClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(azureResourceVar, "is_dr_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAcc_ResourceClusterDrValidation(t *testing.T) {
 	if os.Getenv(SKIP_CLUSTER_RESOURCE_TESTS) == "True" {
 		t.Skip(SKIP_CLUSTER_RESOURCE_TESTS_REASON)
@@ -657,7 +778,7 @@ resource "astro_cluster" "%v" {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
-			// Test: DR enabled on Azure should fail
+			// Test: DR enabled on Azure without dr_region should fail
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
 resource "astro_cluster" "%v" {
@@ -667,13 +788,12 @@ resource "astro_cluster" "%v" {
 	cloud_provider = "AZURE"
 	vpc_subnet_range = "172.20.0.0/20"
 	is_dr_enabled = true
-	dr_region = "eastus2"
 	workspace_ids = []
 }
 `, clusterName, clusterName),
-				ExpectError: regexp.MustCompile(`Disaster Recovery is not supported for 'AZURE' clusters`),
+				ExpectError: regexp.MustCompile(`dr_region is required when is_dr_enabled is true`),
 			},
-			// Test: dr_region on Azure should fail
+			// Test: DR sub-fields without DR enabled on Azure should fail
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
 resource "astro_cluster" "%v" {
@@ -682,11 +802,113 @@ resource "astro_cluster" "%v" {
 	region = "westus2"
 	cloud_provider = "AZURE"
 	vpc_subnet_range = "172.20.0.0/20"
-	dr_region = "eastus2"
+	is_dr_enabled = false
+	dr_vpc_subnet_range = "172.21.0.0/20"
 	workspace_ids = []
 }
 `, clusterName, clusterName),
-				ExpectError: regexp.MustCompile(`dr_region is not allowed for 'AZURE' cluster`),
+				ExpectError: regexp.MustCompile(`dr_vpc_subnet_range is only valid when is_dr_enabled is true`),
+			},
+			// Test: enable_replication_time_control without DR enabled on Azure should fail
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "westus2"
+	cloud_provider = "AZURE"
+	vpc_subnet_range = "172.20.0.0/20"
+	is_dr_enabled = false
+	enable_replication_time_control = true
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				ExpectError: regexp.MustCompile(`enable_replication_time_control is only valid when is_dr_enabled is true`),
+			},
+			// Test: dr_pod_subnet_range (GCP only) on Azure should fail
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "westus2"
+	cloud_provider = "AZURE"
+	vpc_subnet_range = "172.20.0.0/20"
+	dr_pod_subnet_range = "100.67.0.0/16"
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				ExpectError: regexp.MustCompile(`dr_pod_subnet_range is not allowed for 'AZURE' cluster`),
+			},
+			// Test: dr_secondary_vpc_cidr (AWS only) on Azure should fail
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "westus2"
+	cloud_provider = "AZURE"
+	vpc_subnet_range = "172.20.0.0/20"
+	dr_secondary_vpc_cidr = "100.64.0.0/19"
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				ExpectError: regexp.MustCompile(`dr_secondary_vpc_cidr is not allowed for 'AZURE' cluster`),
+			},
+			// Test: explicitly setting enable_replication_time_control to true on Azure with
+			// region/dr_region on different continents should fail
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "eastus2"
+	cloud_provider = "AZURE"
+	vpc_subnet_range = "172.20.0.0/20"
+	is_dr_enabled = true
+	dr_region = "westeurope"
+	enable_replication_time_control = true
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				ExpectError: regexp.MustCompile(`Replication time control requires regions on the same continent`),
+			},
+			// Test: leaving enable_replication_time_control unset with a continent-mismatched
+			// region pair does not fail - the provider simply won't send true to the API
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "eastus2"
+	cloud_provider = "AZURE"
+	vpc_subnet_range = "172.20.0.0/20"
+	is_dr_enabled = true
+	dr_region = "westeurope"
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Test: same continent-mismatch pair does not fail when enable_replication_time_control
+			// is explicitly set to false
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
+resource "astro_cluster" "%v" {
+	name = "%v"
+	type = "DEDICATED"
+	region = "eastus2"
+	cloud_provider = "AZURE"
+	vpc_subnet_range = "172.20.0.0/20"
+	is_dr_enabled = true
+	dr_region = "westeurope"
+	enable_replication_time_control = false
+	workspace_ids = []
+}
+`, clusterName, clusterName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 			// Test: DR sub-fields without DR enabled on AWS should fail
 			{

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -694,7 +694,10 @@ func TestAcc_ResourceClusterAzureEnableDrOnExistingCluster(t *testing.T) {
 			},
 			// Enable DR on the existing cluster via update
 			{
-				PreConfig: func() { waitForClusterStableState(t, azureClusterName) },
+				PreConfig: func() {
+					time.Sleep(2 * time.Minute)
+					waitForClusterStableState(t, azureClusterName)
+				},
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
 					cluster(clusterInput{
 						Name:             azureClusterName,
@@ -714,7 +717,14 @@ func TestAcc_ResourceClusterAzureEnableDrOnExistingCluster(t *testing.T) {
 			// (the cluster() helper omits is_dr_enabled entirely when false, so this
 			// step needs an explicit `is_dr_enabled = false` to exercise the disable path)
 			{
-				PreConfig: func() { waitForClusterStableState(t, azureClusterName) },
+				PreConfig: func() {
+					time.Sleep(2 * time.Minute)
+					// The enable-DR step above can leave a background reconciliation workflow
+					// running well past the point where the API reports the cluster CREATED.
+					// Wait for that workflow to reach an actual terminal state - success or
+					// failure - so a failure there is attributed here, not to the disable step.
+					waitForClusterTerminalState(t, azureClusterName)
+				},
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + fmt.Sprintf(`
 resource "astro_cluster" "%v" {
 	name = "%v"
@@ -728,6 +738,10 @@ resource "astro_cluster" "%v" {
 `, azureClusterName, azureClusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(azureResourceVar, "is_dr_enabled", "false"),
+					func(*terraform.State) error {
+						waitForClusterTerminalState(t, azureClusterName)
+						return nil
+					},
 				),
 			},
 		},
@@ -1261,6 +1275,54 @@ func waitForClusterStableState(t *testing.T, name string) {
 		time.Sleep(interval)
 	}
 	t.Fatalf("Timed out waiting for cluster %s to reach stable state", name)
+}
+
+// waitForClusterTerminalState polls until the cluster reaches a terminal status:
+// either CREATED (success) or one of the failure statuses (UPDATE_FAILED,
+// CREATE_FAILED, ACCESS_DENIED, FAILOVER_FAILED). Unlike waitForClusterStableState,
+// which only recognizes CREATED and otherwise keeps polling until it times out, this
+// fails the test immediately with the actual status when a failure state is reached,
+// so a background reconciliation failure is attributed to the step that caused it
+// rather than to whichever step happens to be running when it eventually surfaces.
+// Used only by TestAcc_ResourceClusterAzureEnableDrOnExistingCluster.
+func waitForClusterTerminalState(t *testing.T, name string) {
+	t.Helper()
+
+	client, err := utils.GetTestHostedPlatformClient()
+	assert.NoError(t, err)
+
+	organizationId := os.Getenv("HOSTED_ORGANIZATION_ID")
+	ctx := context.Background()
+
+	timeout := 60 * time.Minute
+	interval := 30 * time.Second
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		resp, err := client.ListClustersWithResponse(ctx, organizationId, &platform.ListClustersParams{
+			Names: &[]string{name},
+		})
+		if err != nil {
+			t.Logf("Error listing clusters: %v, retrying...", err)
+			time.Sleep(interval)
+			continue
+		}
+		if len(resp.JSON200.Clusters) == 1 {
+			status := resp.JSON200.Clusters[0].Status
+			switch status {
+			case platform.ClusterStatusCREATED:
+				t.Logf("Cluster %s is in terminal state: %s", name, status)
+				return
+			case platform.ClusterStatusUPDATEFAILED, platform.ClusterStatusCREATEFAILED,
+				platform.ClusterStatusACCESSDENIED, platform.ClusterStatusFAILOVERFAILED:
+				t.Fatalf("Cluster %s reached a terminal failure state: %s", name, status)
+			default:
+				t.Logf("Cluster %s status: %s, waiting for terminal state...", name, status)
+			}
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("Timed out waiting for cluster %s to reach a terminal state", name)
 }
 
 func testAccCheckClusterExistence(t *testing.T, name string, isHosted, shouldExist bool) func(state *terraform.State) error {

--- a/internal/provider/resources/resource_cluster_test.go
+++ b/internal/provider/resources/resource_cluster_test.go
@@ -627,11 +627,12 @@ func TestAcc_ResourceClusterAzureWithDr(t *testing.T) {
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
 					cluster(clusterInput{
-						Name:          azureClusterName,
-						Region:        "westus2",
-						CloudProvider: "AZURE",
-						IsDrEnabled:   true,
-						DrRegion:      "eastus2",
+						Name:             azureClusterName,
+						Region:           "westus2",
+						CloudProvider:    "AZURE",
+						IsDrEnabled:      true,
+						DrRegion:         "eastus2",
+						DrVpcSubnetRange: "172.21.0.0/20",
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(azureResourceVar, "name", azureClusterName),
@@ -641,6 +642,7 @@ func TestAcc_ResourceClusterAzureWithDr(t *testing.T) {
 					// Check DR fields
 					resource.TestCheckResourceAttr(azureResourceVar, "is_dr_enabled", "true"),
 					resource.TestCheckResourceAttr(azureResourceVar, "dr_region", "eastus2"),
+					resource.TestCheckResourceAttr(azureResourceVar, "dr_vpc_subnet_range", "172.21.0.0/20"),
 					resource.TestCheckResourceAttrSet(azureResourceVar, "is_failed_over"),
 					resource.TestCheckResourceAttr(azureResourceVar, "enable_replication_time_control", "true"),
 
@@ -695,15 +697,17 @@ func TestAcc_ResourceClusterAzureEnableDrOnExistingCluster(t *testing.T) {
 				PreConfig: func() { waitForClusterStableState(t, azureClusterName) },
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) +
 					cluster(clusterInput{
-						Name:          azureClusterName,
-						Region:        "westus2",
-						CloudProvider: "AZURE",
-						IsDrEnabled:   true,
-						DrRegion:      "eastus2",
+						Name:             azureClusterName,
+						Region:           "westus2",
+						CloudProvider:    "AZURE",
+						IsDrEnabled:      true,
+						DrRegion:         "eastus2",
+						DrVpcSubnetRange: "172.21.0.0/20",
 					}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(azureResourceVar, "is_dr_enabled", "true"),
 					resource.TestCheckResourceAttr(azureResourceVar, "dr_region", "eastus2"),
+					resource.TestCheckResourceAttr(azureResourceVar, "dr_vpc_subnet_range", "172.21.0.0/20"),
 				),
 			},
 			// Disable DR on the existing cluster via update

--- a/internal/provider/schemas/cluster.go
+++ b/internal/provider/schemas/cluster.go
@@ -168,7 +168,7 @@ func ClusterResourceSchemaAttributes(ctx context.Context) map[string]resourceSch
 			Computed:            true,
 		},
 		"is_dr_enabled": resourceSchema.BoolAttribute{
-			MarkdownDescription: "Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.",
+			MarkdownDescription: "Whether Disaster Recovery is enabled on the cluster. Supported for `AWS`, `GCP`, and `AZURE` clusters. For `AWS` and `GCP`, DR can only be enabled at cluster creation time; enabling DR on an existing `AWS` or `GCP` cluster requires the admin API. For `AZURE`, DR can be enabled or disabled on an existing cluster via this resource. Can be set to `false` to disable DR on an existing cluster for any provider.",
 			Optional:            true,
 			Computed:            true,
 		},
@@ -188,7 +188,7 @@ func ClusterResourceSchemaAttributes(ctx context.Context) map[string]resourceSch
 			Computed:            true,
 		},
 		"enable_replication_time_control": resourceSchema.BoolAttribute{
-			MarkdownDescription: "Whether to enable S3 Replication Time Control for Disaster Recovery. Only valid when `is_dr_enabled` is true (AWS only).",
+			MarkdownDescription: "Whether to enable Replication Time Control for Disaster Recovery task log replication. Only valid when `is_dr_enabled` is true. For `AZURE` clusters: if left unset, this is automatically enabled when `region` and `dr_region` are on the same continent, and left disabled otherwise. Explicitly setting this to `true` when `region` and `dr_region` are on different continents will fail at plan time. You may always explicitly set this to `false`, regardless of the region pair.",
 			Optional:            true,
 			Computed:            true,
 		},
@@ -341,7 +341,7 @@ func ClusterDataSourceSchemaAttributes() map[string]datasourceSchema.Attribute {
 			Computed:            true,
 		},
 		"enable_replication_time_control": datasourceSchema.BoolAttribute{
-			MarkdownDescription: "Whether S3 Replication Time Control is enabled for Disaster Recovery (AWS only)",
+			MarkdownDescription: "Whether Replication Time Control is enabled for Disaster Recovery task log replication",
 			Computed:            true,
 		},
 		"is_failed_over": datasourceSchema.BoolAttribute{

--- a/internal/provider/schemas/cluster.go
+++ b/internal/provider/schemas/cluster.go
@@ -636,15 +636,15 @@ func (m nullWhenDrDisabledBoolPlanModifier) MarkdownDescription(ctx context.Cont
 
 func (m nullWhenDrDisabledBoolPlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
 	// Check if is_dr_enabled is being set to false in the plan
-	var isDrEnabled types.Bool
-	diags := req.Plan.GetAttribute(ctx, path.Root("is_dr_enabled"), &isDrEnabled)
+	var isDrEnabledPlan types.Bool
+	diags := req.Plan.GetAttribute(ctx, path.Root("is_dr_enabled"), &isDrEnabledPlan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// If DR is being disabled, plan this attribute as null
-	if !isDrEnabled.IsNull() && !isDrEnabled.IsUnknown() && !isDrEnabled.ValueBool() {
+	if !isDrEnabledPlan.IsNull() && !isDrEnabledPlan.IsUnknown() && !isDrEnabledPlan.ValueBool() {
 		resp.PlanValue = types.BoolNull()
 		return
 	}
@@ -657,5 +657,25 @@ func (m nullWhenDrDisabledBoolPlanModifier) PlanModifyBool(ctx context.Context, 
 	if req.State.Raw.IsNull() {
 		return
 	}
+
+	// If DR is being enabled on a cluster that previously had it disabled (e.g.
+	// enabling DR on an existing Azure cluster via update), the prior state's
+	// value is stale - it is null only because DR was off, not because that's
+	// what this attribute will actually be once DR is on (the API will return a
+	// real true/false). Reusing that stale null here would cause a "provider
+	// produced inconsistent result after apply" error once the API responds
+	// with a concrete value, so leave the plan unknown to be recomputed instead.
+	var isDrEnabledState types.Bool
+	diags = req.State.GetAttribute(ctx, path.Root("is_dr_enabled"), &isDrEnabledState)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	drNewlyEnabled := (isDrEnabledState.IsNull() || !isDrEnabledState.ValueBool()) &&
+		!isDrEnabledPlan.IsNull() && !isDrEnabledPlan.IsUnknown() && isDrEnabledPlan.ValueBool()
+	if drNewlyEnabled {
+		return
+	}
+
 	resp.PlanValue = req.StateValue
 }

--- a/internal/provider/schemas/cluster_plan_modifiers_test.go
+++ b/internal/provider/schemas/cluster_plan_modifiers_test.go
@@ -1,0 +1,165 @@
+package schemas
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+)
+
+// isDrEnabledFailedOverSchema is a minimal schema covering just the two attributes
+// nullWhenDrDisabledBoolPlanModifier reads/writes, enough to exercise it directly
+// without building the full cluster resource schema.
+func isDrEnabledFailedOverSchema() rschema.Schema {
+	return rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"is_dr_enabled":  rschema.BoolAttribute{Optional: true, Computed: true},
+			"is_failed_over": rschema.BoolAttribute{Optional: true, Computed: true},
+		},
+	}
+}
+
+func isDrEnabledFailedOverObjectType() tftypes.Object {
+	return tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"is_dr_enabled":  tftypes.Bool,
+		"is_failed_over": tftypes.Bool,
+	}}
+}
+
+// TestNullWhenDrDisabledBoolPlanModifier_DrNewlyEnabled_LeavesUnknown is a regression
+// test for a "Provider produced inconsistent result after apply: .is_failed_over: was
+// null, but now cty.False" failure seen enabling DR on an existing Azure cluster: when
+// DR transitions from disabled to enabled, the prior state's is_failed_over (null,
+// because DR was off) must not be reused as the plan value, since the API will return
+// a real true/false once DR is actually enabled.
+func TestNullWhenDrDisabledBoolPlanModifier_DrNewlyEnabled_LeavesUnknown(t *testing.T) {
+	ctx := context.Background()
+	s := isDrEnabledFailedOverSchema()
+	ot := isDrEnabledFailedOverObjectType()
+
+	stateRaw := tftypes.NewValue(ot, map[string]tftypes.Value{
+		"is_dr_enabled":  tftypes.NewValue(tftypes.Bool, false),
+		"is_failed_over": tftypes.NewValue(tftypes.Bool, nil),
+	})
+	planRaw := tftypes.NewValue(ot, map[string]tftypes.Value{
+		"is_dr_enabled":  tftypes.NewValue(tftypes.Bool, true),
+		"is_failed_over": tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+	})
+
+	req := planmodifier.BoolRequest{
+		Path:        path.Root("is_failed_over"),
+		State:       tfsdk.State{Schema: s, Raw: stateRaw},
+		Plan:        tfsdk.Plan{Schema: s, Raw: planRaw},
+		ConfigValue: types.BoolNull(),
+		StateValue:  types.BoolNull(),
+		PlanValue:   types.BoolUnknown(),
+	}
+	resp := &planmodifier.BoolResponse{PlanValue: req.PlanValue}
+
+	nullWhenDrDisabledBoolPlanModifier{}.PlanModifyBool(ctx, req, resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.True(t, resp.PlanValue.IsUnknown(), "expected plan value to stay unknown when DR is newly enabled, got %v", resp.PlanValue)
+}
+
+// TestNullWhenDrDisabledBoolPlanModifier_DrAlreadyEnabled_UsesState verifies the
+// UseStateForUnknown-like fallback still applies when DR was already enabled (no
+// disabled->enabled transition), so unrelated updates to an already-DR-enabled
+// cluster don't show a spurious diff on is_failed_over.
+func TestNullWhenDrDisabledBoolPlanModifier_DrAlreadyEnabled_UsesState(t *testing.T) {
+	ctx := context.Background()
+	s := isDrEnabledFailedOverSchema()
+	ot := isDrEnabledFailedOverObjectType()
+
+	stateRaw := tftypes.NewValue(ot, map[string]tftypes.Value{
+		"is_dr_enabled":  tftypes.NewValue(tftypes.Bool, true),
+		"is_failed_over": tftypes.NewValue(tftypes.Bool, false),
+	})
+	planRaw := tftypes.NewValue(ot, map[string]tftypes.Value{
+		"is_dr_enabled":  tftypes.NewValue(tftypes.Bool, true),
+		"is_failed_over": tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+	})
+
+	req := planmodifier.BoolRequest{
+		Path:        path.Root("is_failed_over"),
+		State:       tfsdk.State{Schema: s, Raw: stateRaw},
+		Plan:        tfsdk.Plan{Schema: s, Raw: planRaw},
+		ConfigValue: types.BoolNull(),
+		StateValue:  types.BoolValue(false),
+		PlanValue:   types.BoolUnknown(),
+	}
+	resp := &planmodifier.BoolResponse{PlanValue: req.PlanValue}
+
+	nullWhenDrDisabledBoolPlanModifier{}.PlanModifyBool(ctx, req, resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.False(t, resp.PlanValue.IsUnknown())
+	assert.False(t, resp.PlanValue.IsNull())
+	assert.False(t, resp.PlanValue.ValueBool())
+}
+
+// TestNullWhenDrDisabledBoolPlanModifier_DrDisabling_SetsNull confirms disabling DR
+// still nulls out is_failed_over regardless of the prior state.
+func TestNullWhenDrDisabledBoolPlanModifier_DrDisabling_SetsNull(t *testing.T) {
+	ctx := context.Background()
+	s := isDrEnabledFailedOverSchema()
+	ot := isDrEnabledFailedOverObjectType()
+
+	stateRaw := tftypes.NewValue(ot, map[string]tftypes.Value{
+		"is_dr_enabled":  tftypes.NewValue(tftypes.Bool, true),
+		"is_failed_over": tftypes.NewValue(tftypes.Bool, false),
+	})
+	planRaw := tftypes.NewValue(ot, map[string]tftypes.Value{
+		"is_dr_enabled":  tftypes.NewValue(tftypes.Bool, false),
+		"is_failed_over": tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+	})
+
+	req := planmodifier.BoolRequest{
+		Path:        path.Root("is_failed_over"),
+		State:       tfsdk.State{Schema: s, Raw: stateRaw},
+		Plan:        tfsdk.Plan{Schema: s, Raw: planRaw},
+		ConfigValue: types.BoolNull(),
+		StateValue:  types.BoolValue(false),
+		PlanValue:   types.BoolUnknown(),
+	}
+	resp := &planmodifier.BoolResponse{PlanValue: req.PlanValue}
+
+	nullWhenDrDisabledBoolPlanModifier{}.PlanModifyBool(ctx, req, resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.True(t, resp.PlanValue.IsNull())
+}
+
+// TestNullWhenDrDisabledBoolPlanModifier_Create verifies a brand new resource (no
+// prior state) leaves the plan value unknown to be computed, rather than erroring.
+func TestNullWhenDrDisabledBoolPlanModifier_Create(t *testing.T) {
+	ctx := context.Background()
+	s := isDrEnabledFailedOverSchema()
+	ot := isDrEnabledFailedOverObjectType()
+
+	planRaw := tftypes.NewValue(ot, map[string]tftypes.Value{
+		"is_dr_enabled":  tftypes.NewValue(tftypes.Bool, true),
+		"is_failed_over": tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+	})
+
+	req := planmodifier.BoolRequest{
+		Path:        path.Root("is_failed_over"),
+		State:       tfsdk.State{Schema: s, Raw: tftypes.NewValue(ot, nil)},
+		Plan:        tfsdk.Plan{Schema: s, Raw: planRaw},
+		ConfigValue: types.BoolNull(),
+		StateValue:  types.BoolNull(),
+		PlanValue:   types.BoolUnknown(),
+	}
+	resp := &planmodifier.BoolResponse{PlanValue: req.PlanValue}
+
+	nullWhenDrDisabledBoolPlanModifier{}.PlanModifyBool(ctx, req, resp)
+
+	assert.False(t, resp.Diagnostics.HasError())
+	assert.True(t, resp.PlanValue.IsUnknown())
+}


### PR DESCRIPTION
Allows enabling/disabling DR on Azure clusters.

Reimplements the backend's same-continent check for enable_replication_time_control client-side so an invalid region pair is rejected at plan time. 

The TF provider will pass true for enable replication time control if region and dr region are on the same continent but the user of the tf client did not explicitly set it.

## Description

<!--- Describe the purpose of this pull request. --->

## 🎟 Issue(s)

## 🧪 Functional Testing

<!--- List the functional testing steps to confirm this feature or fix. --->

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [x] Added/updated applicable tests
- [x] Added/updated examples in the `examples/` directory
- [x] Updated any related [documentation](https://github.com/astronomer/docs/)
