### PR TITLE
Fix nil-response panics and add a response-body check at the API boundary

### DIFF
--- a/internal/clients/utils.go
+++ b/internal/clients/utils.go
@@ -89,3 +89,32 @@ func NormalizeAPIError(
 	}
 	return httpResp.StatusCode, nil
 }
+
+// NormalizeAPIResponseWithBody is NormalizeAPIError plus a required-body check. The generated
+// clients fill JSON200 only for a JSON 200, so 201, 204, and non-JSON 200s pass the status check
+// with a nil JSON200 that panics the provider when read into a model. json200 is a parameter so
+// the check can't be skipped; status is returned for the 404 -> RemoveResource path.
+func NormalizeAPIResponseWithBody[T any](
+	ctx context.Context,
+	httpResp *http.Response,
+	body []byte,
+	json200 *T,
+	operation string,
+) (int, diag.Diagnostic) {
+	statusCode, diagnostic := NormalizeAPIError(ctx, httpResp, body)
+	if diagnostic != nil {
+		return statusCode, diagnostic
+	}
+	if json200 == nil {
+		tflog.Error(
+			ctx,
+			"API response contained no body",
+			map[string]interface{}{"operation": operation, "status": statusCode},
+		)
+		return statusCode, diag.NewErrorDiagnostic(
+			"Client error",
+			fmt.Sprintf("Unable to %s, got status %v with no response body", operation, statusCode),
+		)
+	}
+	return statusCode, nil
+}

--- a/internal/clients/utils_test.go
+++ b/internal/clients/utils_test.go
@@ -75,3 +75,86 @@ func TestUnit_NormalizeAPIError(t *testing.T) {
 		})
 	}
 }
+
+func TestUnit_NormalizeAPIResponseWithBody(t *testing.T) {
+	ctx := context.Background()
+
+	type payload struct{ Id string }
+
+	tests := []struct {
+		name           string
+		resp           *http.Response
+		body           []byte
+		json200        *payload
+		expectedStatus int
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:           "SuccessWithBody",
+			resp:           &http.Response{StatusCode: http.StatusOK},
+			json200:        &payload{Id: "id"},
+			expectedStatus: http.StatusOK,
+			expectError:    false,
+		},
+		{
+			name:           "OkWithoutParsedBody",
+			resp:           &http.Response{StatusCode: http.StatusOK},
+			json200:        nil,
+			expectedStatus: http.StatusOK,
+			expectError:    true,
+			errorContains:  "no response body",
+		},
+		{
+			name:           "NoContentHasNoBody",
+			resp:           &http.Response{StatusCode: http.StatusNoContent},
+			json200:        nil,
+			expectedStatus: http.StatusNoContent,
+			expectError:    true,
+			errorContains:  "no response body",
+		},
+		{
+			name:           "CreatedWithoutParsedBody",
+			resp:           &http.Response{StatusCode: http.StatusCreated},
+			json200:        nil,
+			expectedStatus: http.StatusCreated,
+			expectError:    true,
+			errorContains:  "no response body",
+		},
+		{
+			// The status error wins; the body check is never reached
+			name:           "HttpResponseNilTakesPrecedence",
+			resp:           nil,
+			json200:        nil,
+			expectedStatus: http.StatusInternalServerError,
+			expectError:    true,
+			errorContains:  "failed to perform request",
+		},
+		{
+			// 404 must still reach the caller for RemoveResource
+			name:           "StatusErrorTakesPrecedence",
+			resp:           &http.Response{StatusCode: http.StatusNotFound},
+			body:           []byte(`{"message": "not found", "requestId": "123"}`),
+			json200:        nil,
+			expectedStatus: http.StatusNotFound,
+			expectError:    true,
+			errorContains:  "requestId: 123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, diag := clients.NormalizeAPIResponseWithBody(ctx, tt.resp, tt.body, tt.json200, "read thing")
+
+			assert.Equal(t, tt.expectedStatus, status)
+			if tt.expectError {
+				assert.NotNil(t, diag)
+				if tt.errorContains != "" {
+					assert.Contains(t, diag.Detail(), tt.errorContains)
+				}
+			} else {
+				assert.Nil(t, diag)
+			}
+		})
+	}
+}

--- a/internal/provider/common/role.go
+++ b/internal/provider/common/role.go
@@ -160,14 +160,9 @@ func ValidateWorkspaceDeploymentRoles(ctx context.Context, input ValidateWorkspa
 			)}
 		}
 
-		_, diagnostic := clients.NormalizeAPIError(ctx, listDeployments.HTTPResponse, listDeployments.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, listDeployments.HTTPResponse, listDeployments.Body, listDeployments.JSON200, "list deployments")
 		if diagnostic != nil {
 			return diag.Diagnostics{diagnostic}
-		}
-
-		if listDeployments.JSON200 == nil {
-			return diag.Diagnostics{diag.NewErrorDiagnostic(
-				"Client Error", "Unable to list deployments, got nil response")}
 		}
 
 		// Handle an empty page, breaking early

--- a/internal/provider/datasources/data_source_alert.go
+++ b/internal/provider/datasources/data_source_alert.go
@@ -86,14 +86,9 @@ func (d *alertDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, alert.HTTPResponse, alert.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, alert.HTTPResponse, alert.Body, alert.JSON200, "read alert")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if alert.JSON200 == nil {
-		tflog.Error(ctx, "failed to get alert", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read alert, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_alerts.go
+++ b/internal/provider/datasources/data_source_alerts.go
@@ -152,14 +152,9 @@ func (d *alertsDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, alertsResp.HTTPResponse, alertsResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, alertsResp.HTTPResponse, alertsResp.Body, alertsResp.JSON200, "read alerts")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if alertsResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list alerts", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read alerts, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_api_token.go
+++ b/internal/provider/datasources/data_source_api_token.go
@@ -86,14 +86,9 @@ func (d *apiTokenDataSource) Read(ctx context.Context, req datasource.ReadReques
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, apiToken.HTTPResponse, apiToken.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, apiToken.HTTPResponse, apiToken.Body, apiToken.JSON200, "read API token")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if apiToken.JSON200 == nil {
-		tflog.Error(ctx, "failed to get api token", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read api token, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_api_tokens.go
+++ b/internal/provider/datasources/data_source_api_tokens.go
@@ -117,14 +117,9 @@ func (d *apiTokensDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, apiTokensResp.HTTPResponse, apiTokensResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, apiTokensResp.HTTPResponse, apiTokensResp.Body, apiTokensResp.JSON200, "read API tokens")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if apiTokensResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list api tokens", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read api tokens, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_cluster.go
+++ b/internal/provider/datasources/data_source_cluster.go
@@ -94,14 +94,9 @@ func (d *clusterDataSource) Read(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, cluster.HTTPResponse, cluster.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, cluster.HTTPResponse, cluster.Body, cluster.JSON200, "read cluster")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if cluster.JSON200 == nil {
-		tflog.Error(ctx, "failed to get cluster", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read cluster, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_cluster_options.go
+++ b/internal/provider/datasources/data_source_cluster_options.go
@@ -101,15 +101,10 @@ func (d *clusterOptionsDataSource) Read(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, clusterOptionsResp.HTTPResponse, clusterOptionsResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, clusterOptionsResp.HTTPResponse, clusterOptionsResp.Body, clusterOptionsResp.JSON200, "read cluster options")
 
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if clusterOptionsResp.JSON200 == nil {
-		tflog.Error(ctx, "failed to list clusterOptions", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read clusterOptions, got nil response")
 		return
 	}
 	clusterOptions = append(clusterOptions, *clusterOptionsResp.JSON200...)

--- a/internal/provider/datasources/data_source_clusters.go
+++ b/internal/provider/datasources/data_source_clusters.go
@@ -118,14 +118,9 @@ func (d *clustersDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, clustersResp.HTTPResponse, clustersResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, clustersResp.HTTPResponse, clustersResp.Body, clustersResp.JSON200, "read clusters")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if clustersResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list clusters", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read clusters, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_custom_role.go
+++ b/internal/provider/datasources/data_source_custom_role.go
@@ -86,14 +86,9 @@ func (d *customRoleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, customRole.HTTPResponse, customRole.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, customRole.HTTPResponse, customRole.Body, customRole.JSON200, "read custom role")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if customRole.JSON200 == nil {
-		tflog.Error(ctx, "failed to get custom role", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read custom role, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_deployment.go
+++ b/internal/provider/datasources/data_source_deployment.go
@@ -94,14 +94,9 @@ func (d *deploymentDataSource) Read(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, deployment.HTTPResponse, deployment.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, deployment.HTTPResponse, deployment.Body, deployment.JSON200, "read deployment")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if deployment.JSON200 == nil {
-		tflog.Error(ctx, "failed to get deployment", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read deployment, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_deployment_options.go
+++ b/internal/provider/datasources/data_source_deployment_options.go
@@ -113,14 +113,9 @@ func (d *deploymentOptionsDataSource) Read(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, options.HTTPResponse, options.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, options.HTTPResponse, options.Body, options.JSON200, "read deployment options")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if options.JSON200 == nil {
-		tflog.Error(ctx, "failed to get deployment options", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read deployment options, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_deployments.go
+++ b/internal/provider/datasources/data_source_deployments.go
@@ -131,14 +131,9 @@ func (d *deploymentsDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, deploymentsResp.HTTPResponse, deploymentsResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, deploymentsResp.HTTPResponse, deploymentsResp.Body, deploymentsResp.JSON200, "read deployments")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if deploymentsResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list deployments", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read deployments, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_environment_object.go
+++ b/internal/provider/datasources/data_source_environment_object.go
@@ -91,14 +91,9 @@ func (d *environmentObjectDataSource) Read(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read environment object: %s", err))
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, environmentObject.HTTPResponse, environmentObject.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, environmentObject.HTTPResponse, environmentObject.Body, environmentObject.JSON200, "read environment object")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if environmentObject.JSON200 == nil {
-		tflog.Error(ctx, "failed to get environment object", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read environment object, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_environment_objects.go
+++ b/internal/provider/datasources/data_source_environment_objects.go
@@ -120,14 +120,9 @@ func (d *environmentObjectsDataSource) Read(
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list environment objects: %s", err))
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, listResp.HTTPResponse, listResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, listResp.HTTPResponse, listResp.Body, listResp.JSON200, "list environment objects")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if listResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list environment objects", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to list environment objects, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_notification_channel.go
+++ b/internal/provider/datasources/data_source_notification_channel.go
@@ -94,14 +94,9 @@ func (d *notificationChannelDataSource) Read(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, notificationChannel.HTTPResponse, notificationChannel.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, notificationChannel.HTTPResponse, notificationChannel.Body, notificationChannel.JSON200, "read notification channel")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if notificationChannel.JSON200 == nil {
-		tflog.Error(ctx, "failed to get notificationChannel", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read notificationChannel, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_notification_channels.go
+++ b/internal/provider/datasources/data_source_notification_channels.go
@@ -152,14 +152,9 @@ func (d *notificationChannelsDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, notificationChannelsResp.HTTPResponse, notificationChannelsResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, notificationChannelsResp.HTTPResponse, notificationChannelsResp.Body, notificationChannelsResp.JSON200, "read notification channels")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if notificationChannelsResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list notification channels", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read notification channels, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_organization.go
+++ b/internal/provider/datasources/data_source_organization.go
@@ -94,14 +94,9 @@ func (d *organizationDataSource) Read(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, organization.HTTPResponse, organization.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, organization.HTTPResponse, organization.Body, organization.JSON200, "read organization")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if organization.JSON200 == nil {
-		tflog.Error(ctx, "failed to get organization", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read organization, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_team.go
+++ b/internal/provider/datasources/data_source_team.go
@@ -86,14 +86,9 @@ func (d *teamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, team.HTTPResponse, team.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, team.HTTPResponse, team.Body, team.JSON200, "read team")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if team.JSON200 == nil {
-		tflog.Error(ctx, "failed to get team", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read team, got nil response")
 		return
 	}
 
@@ -106,14 +101,9 @@ func (d *teamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		)
 		return
 	}
-	_, diagnostic = clients.NormalizeAPIError(ctx, teamMembers.HTTPResponse, teamMembers.Body)
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, teamMembers.HTTPResponse, teamMembers.Body, teamMembers.JSON200, "read team members")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if teamMembers.JSON200 == nil {
-		tflog.Error(ctx, "failed to get team members", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read team members, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_teams.go
+++ b/internal/provider/datasources/data_source_teams.go
@@ -113,14 +113,9 @@ func (d *teamsDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, teamsResp.HTTPResponse, teamsResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, teamsResp.HTTPResponse, teamsResp.Body, teamsResp.JSON200, "read teams")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if teamsResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list teams", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read teams, got nil response")
 			return
 		}
 
@@ -145,14 +140,9 @@ func (d *teamsDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, teamMembers.HTTPResponse, teamMembers.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, teamMembers.HTTPResponse, teamMembers.Body, teamMembers.JSON200, "read team members")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if teamMembers.JSON200 == nil {
-			tflog.Error(ctx, "failed to get team members", map[string]interface{}{"error": "nil response", "team_id": team.Id})
-			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team members for team %s, got nil response", team.Id))
 			return
 		}
 		teamsWithMembers[team.Id] = teamMembers.JSON200.TeamMembers

--- a/internal/provider/datasources/data_source_user.go
+++ b/internal/provider/datasources/data_source_user.go
@@ -86,14 +86,9 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, user.HTTPResponse, user.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, user.HTTPResponse, user.Body, user.JSON200, "read user")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if user.JSON200 == nil {
-		tflog.Error(ctx, "failed to get user", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read user, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_users.go
+++ b/internal/provider/datasources/data_source_users.go
@@ -114,14 +114,9 @@ func (d *usersDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, usersResp.HTTPResponse, usersResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, usersResp.HTTPResponse, usersResp.Body, usersResp.JSON200, "read users")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if usersResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list users", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read users, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_users_list.go
+++ b/internal/provider/datasources/data_source_users_list.go
@@ -123,14 +123,9 @@ func (d *usersListDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, usersResp.HTTPResponse, usersResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, usersResp.HTTPResponse, usersResp.Body, usersResp.JSON200, "read users")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if usersResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list users", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read users, got nil response")
 			return
 		}
 

--- a/internal/provider/datasources/data_source_workspace.go
+++ b/internal/provider/datasources/data_source_workspace.go
@@ -94,14 +94,9 @@ func (d *workspaceDataSource) Read(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, workspace.HTTPResponse, workspace.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, workspace.HTTPResponse, workspace.Body, workspace.JSON200, "read workspace")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if workspace.JSON200 == nil {
-		tflog.Error(ctx, "failed to get workspace", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to read workspace, got nil response")
 		return
 	}
 

--- a/internal/provider/datasources/data_source_workspaces.go
+++ b/internal/provider/datasources/data_source_workspaces.go
@@ -124,14 +124,9 @@ func (d *workspacesDataSource) Read(
 			)
 			return
 		}
-		_, diagnostic := clients.NormalizeAPIError(ctx, workspacesResp.HTTPResponse, workspacesResp.Body)
+		_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, workspacesResp.HTTPResponse, workspacesResp.Body, workspacesResp.JSON200, "read workspaces")
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if workspacesResp.JSON200 == nil {
-			tflog.Error(ctx, "failed to list workspaces", map[string]interface{}{"error": "nil response"})
-			resp.Diagnostics.AddError("Client Error", "Unable to read workspaces, got nil response")
 			return
 		}
 

--- a/internal/provider/models/alert.go
+++ b/internal/provider/models/alert.go
@@ -281,6 +281,11 @@ func AlertRulesTypesObject(
 		}
 	}
 
+	// Rules can be omitted by the API, arriving as a typed nil
+	if rulesPtr == nil {
+		return types.ObjectNull(schemas.AlertRulesAttributeTypes()), nil
+	}
+
 	// Convert properties to types.Map
 	propertiesMap := make(map[string]interface{})
 	if m, ok := rulesPtr.Properties.(map[string]interface{}); ok {
@@ -333,12 +338,12 @@ func AlertRulesTypesObject(
 func AlertNotificationChannelsTypesSet(ctx context.Context, channels any) (types.Set, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	// Attempt to convert channels to slice
-	var slice []platform.AlertNotificationChannel
+	var slicePtr *[]platform.AlertNotificationChannel
 	switch v := channels.(type) {
 	case []platform.AlertNotificationChannel:
-		slice = v
+		slicePtr = &v
 	case *[]platform.AlertNotificationChannel:
-		slice = *v
+		slicePtr = v
 	default:
 		tflog.Error(ctx, "Unexpected type passed into alert notification channels", map[string]interface{}{"value": channels})
 		return types.Set{}, diag.Diagnostics{
@@ -348,8 +353,14 @@ func AlertNotificationChannelsTypesSet(ctx context.Context, channels any) (types
 			),
 		}
 	}
+
+	// notificationChannels is omitempty, so this can be a typed nil
+	if slicePtr == nil {
+		return types.SetNull(types.ObjectType{AttrTypes: schemas.NotificationChannelsElementAttributeTypes()}), nil
+	}
+
 	var notificationChannelValues []attr.Value
-	for _, anc := range slice {
+	for _, anc := range *slicePtr {
 		// Map AlertNotificationChannel fields into NotificationChannelDataSource via temporary platform.NotificationChannel
 		pc := platform.NotificationChannel{
 			CreatedAt:      anc.CreatedAt,
@@ -401,6 +412,13 @@ func AlertRulesResourceTypesObject(ctx context.Context, rules any) (types.Object
 	if err != nil {
 		return types.Object{}, diag.Diagnostics{
 			diag.NewErrorDiagnostic("Internal Error", fmt.Sprintf("failed to marshal alert rules: %s", err)),
+		}
+	}
+	// rules is Required on the resource, so unlike the data source path a null cannot be
+	// projected into state. Catches both untyped and typed nils without a type switch.
+	if string(raw) == "null" {
+		return types.Object{}, diag.Diagnostics{
+			diag.NewErrorDiagnostic("Internal Error", "AlertRulesResourceTypesObject received nil alert rules"),
 		}
 	}
 	if err := json.Unmarshal(raw, &parsed); err != nil {

--- a/internal/provider/models/alert_test.go
+++ b/internal/provider/models/alert_test.go
@@ -1,0 +1,70 @@
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/terraform-provider-astro/internal/clients/platform"
+	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
+	"github.com/astronomer/terraform-provider-astro/internal/provider/schemas"
+)
+
+// A typed nil used to segfault the provider on `*v`.
+func TestUnit_AlertNotificationChannelsTypesSet_TypedNil(t *testing.T) {
+	set, diags := models.AlertNotificationChannelsTypesSet(context.Background(), (*[]platform.AlertNotificationChannel)(nil))
+	assert.False(t, diags.HasError())
+	assert.Equal(t, types.SetNull(types.ObjectType{AttrTypes: schemas.NotificationChannelsElementAttributeTypes()}), set)
+}
+
+func TestUnit_AlertNotificationChannelsTypesSet_UnexpectedType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{"untyped nil", nil},
+		{"string", "not-a-slice"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, diags := models.AlertNotificationChannelsTypesSet(context.Background(), tc.input)
+			assert.True(t, diags.HasError())
+		})
+	}
+}
+
+func TestUnit_AlertRulesTypesObject_TypedNil(t *testing.T) {
+	obj, diags := models.AlertRulesTypesObject(context.Background(), (*platform.AlertRules)(nil))
+	assert.False(t, diags.HasError())
+	assert.Equal(t, types.ObjectNull(schemas.AlertRulesAttributeTypes()), obj)
+}
+
+// rules is Required on the resource, so nil must error rather than produce a null.
+func TestUnit_AlertRulesResourceTypesObject_Nil(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{"untyped nil", nil},
+		{"typed nil", (*platform.AlertRules)(nil)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, diags := models.AlertRulesResourceTypesObject(context.Background(), tc.input)
+			assert.True(t, diags.HasError())
+		})
+	}
+}
+
+// An alert with notificationChannels omitted must still be readable.
+func TestUnit_AlertDataSourceReadFromResponse_OmittedNotificationChannels(t *testing.T) {
+	var data models.AlertDataSource
+	diags := data.ReadFromResponse(context.Background(), &platform.Alert{Id: "alert-id"})
+	assert.False(t, diags.HasError())
+	assert.Equal(t, types.StringValue("alert-id"), data.Id)
+	assert.True(t, data.NotificationChannels.IsNull())
+}

--- a/internal/provider/models/organization.go
+++ b/internal/provider/models/organization.go
@@ -40,7 +40,7 @@ func (data *Organization) ReadFromResponse(
 	if diags.HasError() {
 		return diags
 	}
-	data.UpdatedBy, diags = SubjectProfileTypesObject(ctx, organization.CreatedBy)
+	data.UpdatedBy, diags = SubjectProfileTypesObject(ctx, organization.UpdatedBy)
 	if diags.HasError() {
 		return diags
 	}

--- a/internal/provider/models/organization_test.go
+++ b/internal/provider/models/organization_test.go
@@ -1,0 +1,27 @@
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/terraform-provider-astro/internal/clients/platform"
+	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
+)
+
+// updated_by was populated from CreatedBy.
+func TestUnit_OrganizationReadFromResponse_UpdatedBy(t *testing.T) {
+	var data models.Organization
+	diags := data.ReadFromResponse(context.Background(), &platform.Organization{
+		Id:        "org-id",
+		Name:      "org",
+		CreatedBy: platform.BasicSubjectProfile{Id: "creator-id"},
+		UpdatedBy: platform.BasicSubjectProfile{Id: "updater-id"},
+	})
+
+	assert.False(t, diags.HasError())
+	assert.Contains(t, data.CreatedBy.String(), "creator-id")
+	assert.Contains(t, data.UpdatedBy.String(), "updater-id")
+	assert.NotContains(t, data.UpdatedBy.String(), "creator-id")
+}

--- a/internal/provider/models/subject_profile.go
+++ b/internal/provider/models/subject_profile.go
@@ -34,41 +34,14 @@ func SubjectProfileTypesObject(
 		bspPtr = &v
 	case *platform.BasicSubjectProfile:
 		bspPtr = v
-	case iam.BasicSubjectProfile, *iam.BasicSubjectProfile:
-		var iamBsp *iam.BasicSubjectProfile
-		if nonPtr, ok := v.(iam.BasicSubjectProfile); ok {
-			iamBsp = &nonPtr
-		} else {
-			iamBsp = v.(*iam.BasicSubjectProfile)
-		}
-
-		bspPtr = &platform.BasicSubjectProfile{
-			ApiTokenName: iamBsp.ApiTokenName,
-			AvatarUrl:    iamBsp.AvatarUrl,
-			FullName:     iamBsp.FullName,
-			Id:           iamBsp.Id,
-			SubjectType:  (*platform.BasicSubjectProfileSubjectType)(iamBsp.SubjectType),
-			Username:     iamBsp.Username,
-		}
-	case platform_v1.BasicSubjectProfile, *platform_v1.BasicSubjectProfile:
-		// platform_v1 (unified public API) has the same field shape but distinct
-		// types — convert to *platform.BasicSubjectProfile so downstream code stays
-		// unchanged.
-		var v1Bsp *platform_v1.BasicSubjectProfile
-		if nonPtr, ok := v.(platform_v1.BasicSubjectProfile); ok {
-			v1Bsp = &nonPtr
-		} else {
-			v1Bsp = v.(*platform_v1.BasicSubjectProfile)
-		}
-
-		bspPtr = &platform.BasicSubjectProfile{
-			ApiTokenName: v1Bsp.ApiTokenName,
-			AvatarUrl:    v1Bsp.AvatarUrl,
-			FullName:     v1Bsp.FullName,
-			Id:           v1Bsp.Id,
-			SubjectType:  (*platform.BasicSubjectProfileSubjectType)(v1Bsp.SubjectType),
-			Username:     v1Bsp.Username,
-		}
+	case iam.BasicSubjectProfile:
+		bspPtr = iamSubjectProfileToPlatform(&v)
+	case *iam.BasicSubjectProfile:
+		bspPtr = iamSubjectProfileToPlatform(v)
+	case platform_v1.BasicSubjectProfile:
+		bspPtr = platformV1SubjectProfileToPlatform(&v)
+	case *platform_v1.BasicSubjectProfile:
+		bspPtr = platformV1SubjectProfileToPlatform(v)
 	default:
 		// Log error and return if none of the types match
 		tflog.Error(
@@ -84,6 +57,11 @@ func SubjectProfileTypesObject(
 		}
 	}
 
+	// The API omits fields like a Team's updatedBy, which arrive here as typed nils
+	if bspPtr == nil {
+		return types.ObjectNull(schemas.SubjectProfileAttributeTypes()), nil
+	}
+
 	subjectProfile := SubjectProfile{
 		Id:           types.StringValue(bspPtr.Id),
 		SubjectType:  types.StringPointerValue((*string)(bspPtr.SubjectType)),
@@ -94,4 +72,33 @@ func SubjectProfileTypesObject(
 	}
 
 	return types.ObjectValueFrom(ctx, schemas.SubjectProfileAttributeTypes(), subjectProfile)
+}
+
+func iamSubjectProfileToPlatform(bsp *iam.BasicSubjectProfile) *platform.BasicSubjectProfile {
+	if bsp == nil {
+		return nil
+	}
+	return &platform.BasicSubjectProfile{
+		ApiTokenName: bsp.ApiTokenName,
+		AvatarUrl:    bsp.AvatarUrl,
+		FullName:     bsp.FullName,
+		Id:           bsp.Id,
+		SubjectType:  (*platform.BasicSubjectProfileSubjectType)(bsp.SubjectType),
+		Username:     bsp.Username,
+	}
+}
+
+// platform_v1 has the same field shape but distinct types.
+func platformV1SubjectProfileToPlatform(bsp *platform_v1.BasicSubjectProfile) *platform.BasicSubjectProfile {
+	if bsp == nil {
+		return nil
+	}
+	return &platform.BasicSubjectProfile{
+		ApiTokenName: bsp.ApiTokenName,
+		AvatarUrl:    bsp.AvatarUrl,
+		FullName:     bsp.FullName,
+		Id:           bsp.Id,
+		SubjectType:  (*platform.BasicSubjectProfileSubjectType)(bsp.SubjectType),
+		Username:     bsp.Username,
+	}
 }

--- a/internal/provider/models/team_roles.go
+++ b/internal/provider/models/team_roles.go
@@ -26,7 +26,14 @@ func (data *TeamRoles) ReadFromResponse(
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 	data.TeamId = types.StringValue(teamId)
-	data.OrganizationRole = types.StringPointerValue((*string)(teamRoles.OrganizationRole))
+	// organization_role is Required, so a null here surfaces as an inconsistent-result error
+	if teamRoles.OrganizationRole == nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic(
+			"Client error",
+			"Unable to read team_roles, got no organization_role in response",
+		)}
+	}
+	data.OrganizationRole = types.StringValue(*teamRoles.OrganizationRole)
 	data.WorkspaceRoles, diags = utils.ObjectSet(ctx, teamRoles.WorkspaceRoles, schemas.WorkspaceRoleAttributeTypes(), WorkspaceRoleTypesObject)
 	if diags.HasError() {
 		return diags

--- a/internal/provider/models/user_roles.go
+++ b/internal/provider/models/user_roles.go
@@ -26,7 +26,14 @@ func (data *UserRoles) ReadFromResponse(
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
 	data.UserId = types.StringValue(userId)
-	data.OrganizationRole = types.StringValue(string(*userRoles.OrganizationRole))
+	// organization_role is Required, so a null here surfaces as an inconsistent-result error
+	if userRoles.OrganizationRole == nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic(
+			"Client error",
+			"Unable to read user_roles, got no organization_role in response",
+		)}
+	}
+	data.OrganizationRole = types.StringValue(*userRoles.OrganizationRole)
 	data.WorkspaceRoles, diags = utils.ObjectSet(ctx, userRoles.WorkspaceRoles, schemas.WorkspaceRoleAttributeTypes(), WorkspaceRoleTypesObject)
 	if diags.HasError() {
 		return diags

--- a/internal/provider/models/user_roles_test.go
+++ b/internal/provider/models/user_roles_test.go
@@ -1,0 +1,51 @@
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
+	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
+)
+
+// organization_role is Required on both resources, so an omitted one must error rather than
+// become a null that Terraform reports as an inconsistent result.
+func TestUnit_RolesReadFromResponse_MissingOrganizationRole(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("user_roles", func(t *testing.T) {
+		var data models.UserRoles
+		diags := data.ReadFromResponse(ctx, "user-id", &iam.SubjectRoles{})
+		assert.True(t, diags.HasError())
+		assert.Contains(t, diags[0].Detail(), "organization_role")
+	})
+
+	t.Run("team_roles", func(t *testing.T) {
+		var data models.TeamRoles
+		diags := data.ReadFromResponse(ctx, "team-id", &iam.SubjectRoles{})
+		assert.True(t, diags.HasError())
+		assert.Contains(t, diags[0].Detail(), "organization_role")
+	})
+}
+
+func TestUnit_RolesReadFromResponse_OrganizationRolePresent(t *testing.T) {
+	ctx := context.Background()
+	roles := &iam.SubjectRoles{OrganizationRole: lo.ToPtr("ORGANIZATION_MEMBER")}
+
+	t.Run("user_roles", func(t *testing.T) {
+		var data models.UserRoles
+		diags := data.ReadFromResponse(ctx, "user-id", roles)
+		assert.False(t, diags.HasError())
+		assert.Equal(t, "ORGANIZATION_MEMBER", data.OrganizationRole.ValueString())
+	})
+
+	t.Run("team_roles", func(t *testing.T) {
+		var data models.TeamRoles
+		diags := data.ReadFromResponse(ctx, "team-id", roles)
+		assert.False(t, diags.HasError())
+		assert.Equal(t, "ORGANIZATION_MEMBER", data.OrganizationRole.ValueString())
+	})
+}

--- a/internal/provider/resources/alerts_bulk_create_test.go
+++ b/internal/provider/resources/alerts_bulk_create_test.go
@@ -1,0 +1,128 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/astronomer/terraform-provider-astro/internal/clients/labs"
+)
+
+// bulkCreate's IDs are zipped against request keys by index, so a chunk that yields fewer IDs than
+// it requested must abort rather than leave a hole - otherwise later keys silently take the wrong
+// alert's ID and Terraform manages (and destroys) the wrong objects.
+func TestUnit_bulkCreate_ShortOrMissingChunkAborts(t *testing.T) {
+	// alertsFor builds a JSON body carrying n alerts with predictable ids.
+	alertsFor := func(prefix string, n int) map[string]any {
+		out := make([]map[string]any, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, map[string]any{
+				"id": prefix, "name": prefix, "entityId": "e", "entityType": "DEPLOYMENT",
+				"organizationId": "o", "severity": "CRITICAL", "type": "DAG_FAILURE",
+				"rules": map[string]any{}, "createdAt": "2024-01-01T00:00:00Z",
+				"updatedAt": "2024-01-01T00:00:00Z",
+				"createdBy": map[string]any{"id": "u"}, "updatedBy": map[string]any{"id": "u"},
+			})
+		}
+		return map[string]any{"alerts": out}
+	}
+
+	tests := []struct {
+		name      string
+		respond   func(w http.ResponseWriter, call int)
+		wantIds   int
+		wantError string
+	}{
+		{
+			name: "success returns one id per request",
+			respond: func(w http.ResponseWriter, call int) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(alertsFor("ok", alertsBulkCreateLimit))
+			},
+			wantIds: alertsBulkCreateLimit,
+		},
+		{
+			// A 204 leaves JSON200 nil. Previously the chunk was skipped and the loop continued.
+			name: "no-content chunk aborts instead of being skipped",
+			respond: func(w http.ResponseWriter, call int) {
+				w.WriteHeader(http.StatusNoContent)
+			},
+			wantIds:   0,
+			wantError: "no response body",
+		},
+		{
+			name: "short chunk aborts",
+			respond: func(w http.ResponseWriter, call int) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(alertsFor("short", alertsBulkCreateLimit-1))
+			},
+			wantIds:   0,
+			wantError: "the API returned 29",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			call := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				call++
+				tc.respond(w, call)
+			}))
+			t.Cleanup(srv.Close)
+			client, err := labs.NewLabsClient(srv.URL, "token", "test")
+			require.NoError(t, err)
+
+			r := &alertsResource{labsClient: client, organizationId: "org"}
+			reqs := make([]labs.CreateAlertRequest, alertsBulkCreateLimit)
+			ids, diags := r.bulkCreate(context.Background(), reqs)
+
+			assert.Len(t, ids, tc.wantIds)
+			if tc.wantError == "" {
+				assert.False(t, diags.HasError())
+				return
+			}
+			require.True(t, diags.HasError())
+			assert.Contains(t, diags[0].Detail(), tc.wantError)
+		})
+	}
+}
+
+// The prefix property the positional zip depends on: when a later chunk fails, the IDs from
+// earlier chunks are still returned, and still line up with the first N requests.
+func TestUnit_bulkCreate_KeepsValidPrefixOnLaterChunkFailure(t *testing.T) {
+	call := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		if call == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			alerts := make([]map[string]any, 0, alertsBulkCreateLimit)
+			for i := 0; i < alertsBulkCreateLimit; i++ {
+				alerts = append(alerts, map[string]any{
+					"id": "first", "name": "n", "entityId": "e", "entityType": "DEPLOYMENT",
+					"organizationId": "o", "severity": "CRITICAL", "type": "DAG_FAILURE",
+					"rules": map[string]any{}, "createdAt": "2024-01-01T00:00:00Z",
+					"updatedAt": "2024-01-01T00:00:00Z",
+					"createdBy": map[string]any{"id": "u"}, "updatedBy": map[string]any{"id": "u"},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"alerts": alerts})
+			return
+		}
+		w.WriteHeader(http.StatusNoContent) // second chunk comes back bodiless
+	}))
+	t.Cleanup(srv.Close)
+	client, err := labs.NewLabsClient(srv.URL, "token", "test")
+	require.NoError(t, err)
+
+	r := &alertsResource{labsClient: client, organizationId: "org"}
+	ids, diags := r.bulkCreate(context.Background(), make([]labs.CreateAlertRequest, alertsBulkCreateLimit+5))
+
+	assert.True(t, diags.HasError())
+	// Exactly the first chunk, so keys[0:30] still map to their own alerts.
+	assert.Len(t, ids, alertsBulkCreateLimit)
+}

--- a/internal/provider/resources/resource_agent_token.go
+++ b/internal/provider/resources/resource_agent_token.go
@@ -109,14 +109,9 @@ func (r *AgentTokenResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, createResp.HTTPResponse, createResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, createResp.HTTPResponse, createResp.Body, createResp.JSON200, "create agent token")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if createResp.JSON200 == nil {
-		tflog.Error(ctx, "failed to create agent token", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to create agent token, got nil response")
 		return
 	}
 	if createResp.JSON200.Token == nil {
@@ -158,7 +153,7 @@ func (r *AgentTokenResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, getResp.HTTPResponse, getResp.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, getResp.HTTPResponse, getResp.Body, getResp.JSON200, "read agent token")
 	if statusCode == http.StatusNotFound {
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/resources/resource_alert.go
+++ b/internal/provider/resources/resource_alert.go
@@ -103,7 +103,7 @@ func (r *alertResource) Create(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create alert: %s", err))
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, alertResp.HTTPResponse, alertResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, alertResp.HTTPResponse, alertResp.Body, alertResp.JSON200, "create alert")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return
@@ -150,7 +150,7 @@ func (r *alertResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, alert.HTTPResponse, alert.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, alert.HTTPResponse, alert.Body, alert.JSON200, "read alert")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -200,7 +200,7 @@ func (r *alertResource) Update(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update alert: %s", err))
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, alertResp.HTTPResponse, alertResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, alertResp.HTTPResponse, alertResp.Body, alertResp.JSON200, "update alert")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return

--- a/internal/provider/resources/resource_alerts.go
+++ b/internal/provider/resources/resource_alerts.go
@@ -347,14 +347,24 @@ func (r *alertsResource) bulkCreate(ctx context.Context, reqs []labs.CreateAlert
 			diags.AddError("Client Error", fmt.Sprintf("Unable to bulk create alerts: %s", err))
 			return createdIds, diags
 		}
-		if _, d := clients.NormalizeAPIError(ctx, alertResp.HTTPResponse, alertResp.Body); d != nil {
+		// Callers zip these IDs against request keys by index, so skipping a chunk or taking a
+		// short one would map every later key to the wrong alert. Stop instead, which leaves
+		// createdIds a valid prefix of the requests.
+		if _, d := clients.NormalizeAPIResponseWithBody(ctx, alertResp.HTTPResponse, alertResp.Body, alertResp.JSON200, "bulk create alerts"); d != nil {
 			diags.Append(d)
 			return createdIds, diags
 		}
-		if alertResp.JSON200 != nil {
-			for _, a := range alertResp.JSON200.Alerts {
-				createdIds = append(createdIds, a.Id)
-			}
+		if len(alertResp.JSON200.Alerts) != len(chunk) {
+			tflog.Error(ctx, "bulk create alerts returned an unexpected number of alerts", map[string]interface{}{
+				"requested": len(chunk), "returned": len(alertResp.JSON200.Alerts),
+			})
+			diags.AddError("Client Error", fmt.Sprintf(
+				"Unable to bulk create alerts, requested %d but the API returned %d",
+				len(chunk), len(alertResp.JSON200.Alerts)))
+			return createdIds, diags
+		}
+		for _, a := range alertResp.JSON200.Alerts {
+			createdIds = append(createdIds, a.Id)
 		}
 	}
 	return createdIds, diags

--- a/internal/provider/resources/resource_allowed_ip_address_ranges.go
+++ b/internal/provider/resources/resource_allowed_ip_address_ranges.go
@@ -339,15 +339,10 @@ func (r *allowedIpAddressRangesResource) listAllRanges(ctx context.Context) ([]i
 			diags.AddError("Client Error", fmt.Sprintf("Unable to list allowed IP address ranges: %s", err))
 			return all, diags
 		}
-		if _, d := clients.NormalizeAPIError(ctx, listResp.HTTPResponse, listResp.Body); d != nil {
+		// A missing body must not read as "the list is empty" - for this authoritative resource
+		// that would wipe every managed range from state and plan their deletion.
+		if _, d := clients.NormalizeAPIResponseWithBody(ctx, listResp.HTTPResponse, listResp.Body, listResp.JSON200, "list allowed IP address ranges"); d != nil {
 			diags.Append(d)
-			return all, diags
-		}
-		// A success status with no parseable JSON body (e.g. a proxy/gateway 200 with an HTML page, or
-		// a 204) must not be read as "the list is empty" - for this authoritative resource that would
-		// silently wipe every managed range from state and plan their deletion. Surface it as an error.
-		if listResp.JSON200 == nil {
-			diags.AddError("Client Error", "Unable to list allowed IP address ranges: the API returned a success status with no parseable response body")
 			return all, diags
 		}
 		all = append(all, listResp.JSON200.AllowedIpAddressRanges...)

--- a/internal/provider/resources/resource_api_token.go
+++ b/internal/provider/resources/resource_api_token.go
@@ -177,17 +177,9 @@ func (r *ApiTokenResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, apiToken.HTTPResponse, apiToken.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, apiToken.HTTPResponse, apiToken.Body, apiToken.JSON200, "create API token")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if apiToken.JSON200 == nil {
-		tflog.Error(ctx, "failed to create API token", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError(
-			"Client Error",
-			"Unable to create API token, got nil response",
-		)
 		return
 	}
 	tokenId := apiToken.JSON200.Id
@@ -232,17 +224,9 @@ func (r *ApiTokenResource) Create(
 		)
 		return
 	}
-	_, diagnostic = clients.NormalizeAPIError(ctx, apiTokenResp.HTTPResponse, apiTokenResp.Body)
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, apiTokenResp.HTTPResponse, apiTokenResp.Body, apiTokenResp.JSON200, "create and get API token")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if apiTokenResp.JSON200 == nil {
-		tflog.Error(ctx, "failed to get API token", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError(
-			"Client Error",
-			"Unable to get API token after creation, got nil response",
-		)
 		return
 	}
 	if apiToken.JSON200.Token == nil {
@@ -295,7 +279,7 @@ func (r *ApiTokenResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, apiToken.HTTPResponse, apiToken.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, apiToken.HTTPResponse, apiToken.Body, apiToken.JSON200, "read API token")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -459,6 +443,11 @@ func (r *ApiTokenResource) Update(
 			"Client Error",
 			fmt.Sprintf("Unable to update API token and get API token, got error: %s", err),
 		)
+		return
+	}
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, apiTokenResp.HTTPResponse, apiTokenResp.Body, apiTokenResp.JSON200, "update and get API token")
+	if diagnostic != nil {
+		resp.Diagnostics.Append(diagnostic)
 		return
 	}
 
@@ -689,7 +678,7 @@ func (r *ApiTokenResource) HasValidWorkspaces(ctx context.Context, workspaceRole
 			),
 		}
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, workspaces.HTTPResponse, workspaces.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, workspaces.HTTPResponse, workspaces.Body, workspaces.JSON200, "list workspaces")
 	if diagnostic != nil {
 		return diag.Diagnostics{diagnostic}
 	}
@@ -741,7 +730,7 @@ func (r *ApiTokenResource) HasValidDeployments(ctx context.Context, deploymentRo
 			),
 		}
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, deployments.HTTPResponse, deployments.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, deployments.HTTPResponse, deployments.Body, deployments.JSON200, "list deployments")
 	if diagnostic != nil {
 		return diag.Diagnostics{diagnostic}
 	}

--- a/internal/provider/resources/resource_cluster.go
+++ b/internal/provider/resources/resource_cluster.go
@@ -214,7 +214,7 @@ func (r *ClusterResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, cluster.HTTPResponse, cluster.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, cluster.HTTPResponse, cluster.Body, cluster.JSON200, "create cluster")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return
@@ -276,7 +276,7 @@ func (r *ClusterResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, cluster.HTTPResponse, cluster.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, cluster.HTTPResponse, cluster.Body, cluster.JSON200, "read cluster")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -375,7 +375,7 @@ func (r *ClusterResource) Update(
 			tflog.Error(ctx, "failed to update cluster", map[string]interface{}{"error": apiErr})
 			return retry.NonRetryableError(fmt.Errorf("unable to update cluster, got error: %s", apiErr))
 		}
-		statusCode, diagnostic := clients.NormalizeAPIError(ctx, cluster.HTTPResponse, cluster.Body)
+		statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, cluster.HTTPResponse, cluster.Body, cluster.JSON200, "update cluster")
 		if statusCode == http.StatusConflict {
 			// Workflow is already running, retry after a delay
 			tflog.Info(ctx, "cluster workflow in progress, retrying update", map[string]interface{}{"clusterId": data.Id.ValueString()})

--- a/internal/provider/resources/resource_custom_role.go
+++ b/internal/provider/resources/resource_custom_role.go
@@ -129,17 +129,9 @@ func (r *customRoleResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, customRole.HTTPResponse, customRole.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, customRole.HTTPResponse, customRole.Body, customRole.JSON200, "create custom role")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if customRole.JSON200 == nil {
-		tflog.Error(ctx, "failed to create custom role", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError(
-			"Client Error",
-			"Unable to create custom role, got nil response",
-		)
 		return
 	}
 
@@ -183,7 +175,7 @@ func (r *customRoleResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, customRole.HTTPResponse, customRole.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, customRole.HTTPResponse, customRole.Body, customRole.JSON200, "read custom role")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -192,14 +184,6 @@ func (r *customRoleResource) Read(
 	}
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if customRole.JSON200 == nil {
-		tflog.Error(ctx, "failed to get custom role", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError(
-			"Client Error",
-			"Unable to get custom role, got nil response",
-		)
 		return
 	}
 
@@ -272,17 +256,9 @@ func (r *customRoleResource) Update(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, customRole.HTTPResponse, customRole.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, customRole.HTTPResponse, customRole.Body, customRole.JSON200, "update custom role")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if customRole.JSON200 == nil {
-		tflog.Error(ctx, "failed to update custom role", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError(
-			"Client Error",
-			"Unable to update custom role, got nil response",
-		)
 		return
 	}
 

--- a/internal/provider/resources/resource_deployment.go
+++ b/internal/provider/resources/resource_deployment.go
@@ -312,7 +312,7 @@ func (r *DeploymentResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, deployment.HTTPResponse, deployment.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, deployment.HTTPResponse, deployment.Body, deployment.JSON200, "create deployment")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return
@@ -363,7 +363,7 @@ func (r *DeploymentResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, deployment.HTTPResponse, deployment.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, deployment.HTTPResponse, deployment.Body, deployment.JSON200, "read deployment")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -607,7 +607,7 @@ func (r *DeploymentResource) Update(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, deployment.HTTPResponse, deployment.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, deployment.HTTPResponse, deployment.Body, deployment.JSON200, "update deployment")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return
@@ -1231,11 +1231,11 @@ func (r *DeploymentResource) GetLatestAstroRuntimeVersion(ctx context.Context, d
 			fmt.Sprintf("Unable to get deployment options for deployment creation, got error: %s", err),
 		)
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, deploymentOptions.HTTPResponse, deploymentOptions.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, deploymentOptions.HTTPResponse, deploymentOptions.Body, deploymentOptions.JSON200, "read deployment options")
 	if diagnostic != nil {
 		return "", diagnostic
 	}
-	if deploymentOptions.JSON200 == nil || len(deploymentOptions.JSON200.RuntimeReleases) == 0 {
+	if len(deploymentOptions.JSON200.RuntimeReleases) == 0 {
 		return "", diag.NewErrorDiagnostic(
 			"Client Error",
 			"Unable to get runtime releases for deployment creation, got empty runtime releases",

--- a/internal/provider/resources/resource_environment_object.go
+++ b/internal/provider/resources/resource_environment_object.go
@@ -108,14 +108,9 @@ func (r *environmentObjectResource) Create(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create environment object, got error: %s", err))
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, createResp.HTTPResponse, createResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, createResp.HTTPResponse, createResp.Body, createResp.JSON200, "create environment object")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if createResp.JSON200 == nil {
-		tflog.Error(ctx, "failed to create environment object", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to create environment object, got nil response")
 		return
 	}
 
@@ -133,14 +128,9 @@ func (r *environmentObjectResource) Create(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get environment object after create, got error: %s", err))
 		return
 	}
-	_, diagnostic = clients.NormalizeAPIError(ctx, getResp.HTTPResponse, getResp.Body)
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, getResp.HTTPResponse, getResp.Body, getResp.JSON200, "create and get environment object")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if getResp.JSON200 == nil {
-		tflog.Error(ctx, "failed to get environment object after create", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to get environment object after create, got nil response")
 		return
 	}
 
@@ -179,18 +169,13 @@ func (r *environmentObjectResource) Read(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get environment object, got error: %s", err))
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, envObj.HTTPResponse, envObj.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, envObj.HTTPResponse, envObj.Body, envObj.JSON200, "read environment object")
 	if statusCode == http.StatusNotFound {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if envObj.JSON200 == nil {
-		tflog.Error(ctx, "failed to get environment object", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to get environment object, got nil response")
 		return
 	}
 
@@ -247,14 +232,9 @@ func (r *environmentObjectResource) Update(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get environment object after update, got error: %s", err))
 		return
 	}
-	_, diagnostic = clients.NormalizeAPIError(ctx, getResp.HTTPResponse, getResp.Body)
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, getResp.HTTPResponse, getResp.Body, getResp.JSON200, "update and get environment object")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if getResp.JSON200 == nil {
-		tflog.Error(ctx, "failed to get environment object after update", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError("Client Error", "Unable to get environment object after update, got nil response")
 		return
 	}
 

--- a/internal/provider/resources/resource_hybrid_cluster_workspace_authorization.go
+++ b/internal/provider/resources/resource_hybrid_cluster_workspace_authorization.go
@@ -114,7 +114,7 @@ func (r *hybridClusterWorkspaceAuthorizationResource) MutateRoles(
 		)
 		return diags
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, cluster.HTTPResponse, cluster.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, cluster.HTTPResponse, cluster.Body, cluster.JSON200, "update hybrid cluster workspace authorization")
 	if diagnostic != nil {
 		diags.Append(diagnostic)
 		return diags
@@ -187,7 +187,7 @@ func (r *hybridClusterWorkspaceAuthorizationResource) Read(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get cluster, got error: %s", err))
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, cluster.HTTPResponse, cluster.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, cluster.HTTPResponse, cluster.Body, cluster.JSON200, "read hybrid cluster workspace authorization")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -275,7 +275,7 @@ func (r *hybridClusterWorkspaceAuthorizationResource) Delete(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, cluster.HTTPResponse, cluster.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, cluster.HTTPResponse, cluster.Body, cluster.JSON200, "delete hybrid cluster workspace authorization")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return

--- a/internal/provider/resources/resource_notification_channel.go
+++ b/internal/provider/resources/resource_notification_channel.go
@@ -229,7 +229,7 @@ func (r *notificationChannelResource) Create(
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create notification channel: %s", err))
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, notificationChannelResp.HTTPResponse, notificationChannelResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, notificationChannelResp.HTTPResponse, notificationChannelResp.Body, notificationChannelResp.JSON200, "create notification channel")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return
@@ -276,7 +276,7 @@ func (r *notificationChannelResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, notificationChannel.HTTPResponse, notificationChannel.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, notificationChannel.HTTPResponse, notificationChannel.Body, notificationChannel.JSON200, "read notification channel")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -456,7 +456,7 @@ func (r *notificationChannelResource) Update(
 		resp.Diagnostics.AddError("API Error", fmt.Sprintf("Failed to update notification channel: %s", err))
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, notificationChannelResp.HTTPResponse, notificationChannelResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, notificationChannelResp.HTTPResponse, notificationChannelResp.Body, notificationChannelResp.JSON200, "update notification channel")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return

--- a/internal/provider/resources/resource_team.go
+++ b/internal/provider/resources/resource_team.go
@@ -199,17 +199,9 @@ func (r *TeamResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, team.HTTPResponse, team.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, team.HTTPResponse, team.Body, team.JSON200, "create team")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
-		return
-	}
-	if team.JSON200 == nil {
-		tflog.Error(ctx, "failed to create Team", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError(
-			"Client Error",
-			"Unable to create Team, got nil response",
-		)
 		return
 	}
 
@@ -260,6 +252,11 @@ func (r *TeamResource) Create(
 		)
 		return
 	}
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, teamResp.HTTPResponse, teamResp.Body, teamResp.JSON200, "create and get team")
+	if diagnostic != nil {
+		resp.Diagnostics.Append(diagnostic)
+		return
+	}
 
 	diags = data.ReadFromResponse(ctx, teamResp.JSON200, memberIdsPtr)
 	if diags.HasError() {
@@ -302,7 +299,7 @@ func (r *TeamResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, team.HTTPResponse, team.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, team.HTTPResponse, team.Body, team.JSON200, "read team")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -433,6 +430,11 @@ func (r *TeamResource) Update(
 		)
 		return
 	}
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, teamResp.HTTPResponse, teamResp.Body, teamResp.JSON200, "update and get team")
+	if diagnostic != nil {
+		resp.Diagnostics.Append(diagnostic)
+		return
+	}
 
 	diags = data.ReadFromResponse(ctx, teamResp.JSON200, newMemberIdsPtr)
 	if diags.HasError() {
@@ -504,17 +506,9 @@ func (r *TeamResource) CheckOrganizationIsScim(ctx context.Context) diag.Diagnos
 			),
 		}
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, org.HTTPResponse, org.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, org.HTTPResponse, org.Body, org.JSON200, "read organization")
 	if diagnostic != nil {
 		return diag.Diagnostics{diagnostic}
-	}
-	if org.JSON200 == nil {
-		tflog.Error(ctx, "failed to get organization", map[string]interface{}{"error": "nil response"})
-		return diag.Diagnostics{
-			diag.NewErrorDiagnostic(
-				"Client Error",
-				fmt.Sprintf("Unable to read organization %v, got nil response", r.OrganizationId)),
-		}
 	}
 	if org.JSON200.IsScimEnabled {
 		return diag.Diagnostics{
@@ -544,7 +538,7 @@ func (r *TeamResource) UpdateTeamMembers(ctx context.Context, data models.TeamRe
 			),
 		}
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, teamMembersResp.HTTPResponse, teamMembersResp.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, teamMembersResp.HTTPResponse, teamMembersResp.Body, teamMembersResp.JSON200, "list team members")
 	if diagnostic != nil {
 		return nil, diag.Diagnostics{diagnostic}
 	}

--- a/internal/provider/resources/resource_team_membership.go
+++ b/internal/provider/resources/resource_team_membership.go
@@ -149,17 +149,13 @@ func (r *teamMembershipResource) Read(
 			)
 			return
 		}
-		statusCode, diagnostic := clients.NormalizeAPIError(ctx, membersResp.HTTPResponse, membersResp.Body)
+		statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, membersResp.HTTPResponse, membersResp.Body, membersResp.JSON200, "list team members")
 		if statusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}
 		if diagnostic != nil {
 			resp.Diagnostics.Append(diagnostic)
-			return
-		}
-		if membersResp.JSON200 == nil {
-			resp.Diagnostics.AddError("Client Error", "Unable to list team members, got nil response")
 			return
 		}
 

--- a/internal/provider/resources/resource_team_roles.go
+++ b/internal/provider/resources/resource_team_roles.go
@@ -157,7 +157,7 @@ func (r *teamRolesResource) MutateRoles(
 		)
 		return diags
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, teamRoles.HTTPResponse, teamRoles.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, teamRoles.HTTPResponse, teamRoles.Body, teamRoles.JSON200, "update team roles")
 	if diagnostic != nil {
 		diags.Append(diagnostic)
 		return diags
@@ -233,7 +233,7 @@ func (r *teamRolesResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, teamRoles.HTTPResponse, teamRoles.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, teamRoles.HTTPResponse, teamRoles.Body, teamRoles.JSON200, "read team roles")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -328,7 +328,7 @@ func (r *teamRolesResource) Delete(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, teamRoles.HTTPResponse, teamRoles.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, teamRoles.HTTPResponse, teamRoles.Body, teamRoles.JSON200, "delete team roles")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return

--- a/internal/provider/resources/resource_user_invite.go
+++ b/internal/provider/resources/resource_user_invite.go
@@ -107,7 +107,7 @@ func (r *UserInviteResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, userInvite.HTTPResponse, userInvite.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, userInvite.HTTPResponse, userInvite.Body, userInvite.JSON200, "create user invite")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return
@@ -179,7 +179,7 @@ func (r *UserInviteResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, user.HTTPResponse, user.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, user.HTTPResponse, user.Body, user.JSON200, "read user invite")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -298,7 +298,7 @@ func (r *UserInviteResource) Update(
 		)
 		return
 	}
-	_, diagnostic = clients.NormalizeAPIError(ctx, userInvite.HTTPResponse, userInvite.Body)
+	_, diagnostic = clients.NormalizeAPIResponseWithBody(ctx, userInvite.HTTPResponse, userInvite.Body, userInvite.JSON200, "update user invite")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return

--- a/internal/provider/resources/resource_user_roles.go
+++ b/internal/provider/resources/resource_user_roles.go
@@ -136,7 +136,7 @@ func (r *UserRolesResource) MutateRoles(
 		)
 		return diags
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, userRoles.HTTPResponse, userRoles.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, userRoles.HTTPResponse, userRoles.Body, userRoles.JSON200, "update user roles")
 	if diagnostic != nil {
 		diags.Append(diagnostic)
 		return diags
@@ -202,13 +202,15 @@ func (r *UserRolesResource) Read(
 		)
 		return
 	}
-	// Check if the response is valid before accessing fields
-	if userRoles.JSON200 == nil {
-		tflog.Error(ctx, "failed to get user_roles", map[string]interface{}{"error": "nil response"})
-		resp.Diagnostics.AddError(
-			"Client Error",
-			fmt.Sprintf("Unable to get user_roles for user '%s', got nil response", userId),
-		)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, userRoles.HTTPResponse, userRoles.Body, userRoles.JSON200, "read user roles")
+	// If the resource no longer exists, it is recommended to ignore the errors
+	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
+	if statusCode == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if diagnostic != nil {
+		resp.Diagnostics.Append(diagnostic)
 		return
 	}
 
@@ -221,21 +223,10 @@ func (r *UserRolesResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, userRoles.HTTPResponse, userRoles.Body)
-	// If the resource no longer exists, it is recommended to ignore the errors
-	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
-	if statusCode == http.StatusNotFound {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-	if diagnostic != nil {
-		resp.Diagnostics.Append(diagnostic)
-		return
-	}
 
 	// Generate subjectRoles from the get user API response
 	subjectRoles := iam.SubjectRoles{
-		OrganizationRole: lo.ToPtr(string(*userRoles.JSON200.OrganizationRole)),
+		OrganizationRole: (*string)(userRoles.JSON200.OrganizationRole),
 		WorkspaceRoles:   userRoles.JSON200.WorkspaceRoles,
 		DeploymentRoles:  userRoles.JSON200.DeploymentRoles,
 		DagRoles:         userRoles.JSON200.DagRoles,
@@ -312,7 +303,7 @@ func (r *UserRolesResource) Delete(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, userRoles.HTTPResponse, userRoles.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, userRoles.HTTPResponse, userRoles.Body, userRoles.JSON200, "delete user roles")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return

--- a/internal/provider/resources/resource_workspace.go
+++ b/internal/provider/resources/resource_workspace.go
@@ -104,7 +104,7 @@ func (r *workspaceResource) Create(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, workspace.HTTPResponse, workspace.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, workspace.HTTPResponse, workspace.Body, workspace.JSON200, "create workspace")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return
@@ -150,7 +150,7 @@ func (r *workspaceResource) Read(
 		)
 		return
 	}
-	statusCode, diagnostic := clients.NormalizeAPIError(ctx, workspace.HTTPResponse, workspace.Body)
+	statusCode, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, workspace.HTTPResponse, workspace.Body, workspace.JSON200, "read workspace")
 	// If the resource no longer exists, it is recommended to ignore the errors
 	// and call RemoveResource to remove the resource from the state. The next Terraform plan will recreate the resource.
 	if statusCode == http.StatusNotFound {
@@ -208,7 +208,7 @@ func (r *workspaceResource) Update(
 		)
 		return
 	}
-	_, diagnostic := clients.NormalizeAPIError(ctx, workspace.HTTPResponse, workspace.Body)
+	_, diagnostic := clients.NormalizeAPIResponseWithBody(ctx, workspace.HTTPResponse, workspace.Body, workspace.JSON200, "update workspace")
 	if diagnostic != nil {
 		resp.Diagnostics.Append(diagnostic)
 		return

--- a/internal/provider/schemas/subject_profile_test.go
+++ b/internal/provider/schemas/subject_profile_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
 	"github.com/astronomer/terraform-provider-astro/internal/clients/platform"
+	platform_v1 "github.com/astronomer/terraform-provider-astro/internal/clients/platform_v1"
 	"github.com/astronomer/terraform-provider-astro/internal/provider/models"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/samber/lo"
@@ -35,6 +36,27 @@ func TestSubjectProfileTypesObject(t *testing.T) {
 				_, diags := models.SubjectProfileTypesObject(ctx, tc.input)
 				assert.True(t, diags.HasError())
 				assert.Contains(t, diags[0].Detail(), "SubjectProfileTypesObject expects a BasicSubjectProfile type but did not receive one")
+			})
+		}
+	})
+
+	// A typed nil is real API data (an omitted field); an untyped nil is a caller bug and
+	// still errors above.
+	t.Run("should return null object if subject profile is a typed nil", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input any
+		}{
+			{"nil *platform.BasicSubjectProfile", (*platform.BasicSubjectProfile)(nil)},
+			{"nil *iam.BasicSubjectProfile", (*iam.BasicSubjectProfile)(nil)},
+			{"nil *platform_v1.BasicSubjectProfile", (*platform_v1.BasicSubjectProfile)(nil)},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				subjectProfileModel, diags := models.SubjectProfileTypesObject(ctx, tc.input)
+				assert.False(t, diags.HasError())
+				assert.Equal(t, types.ObjectNull(schemas.SubjectProfileAttributeTypes()), subjectProfileModel)
 			})
 		}
 	})
@@ -96,6 +118,36 @@ func TestSubjectProfileTypesObject(t *testing.T) {
 			{
 				"just id - iam.BasicSubjectProfile",
 				iam.BasicSubjectProfile{Id: "id"},
+				models.SubjectProfile{
+					Id:           types.StringValue("id"),
+					SubjectType:  types.StringNull(),
+					Username:     types.StringNull(),
+					FullName:     types.StringNull(),
+					AvatarUrl:    types.StringNull(),
+					ApiTokenName: types.StringNull(),
+				},
+			},
+			{
+				"user - &platform_v1.BasicSubjectProfile",
+				&platform_v1.BasicSubjectProfile{
+					AvatarUrl:   lo.ToPtr("avatar_url"),
+					FullName:    lo.ToPtr("full_name"),
+					Id:          "id",
+					SubjectType: (*platform_v1.BasicSubjectProfileSubjectType)(lo.ToPtr("USER")),
+					Username:    lo.ToPtr("username"),
+				},
+				models.SubjectProfile{
+					Id:           types.StringValue("id"),
+					SubjectType:  types.StringValue("USER"),
+					Username:     types.StringValue("username"),
+					FullName:     types.StringValue("full_name"),
+					AvatarUrl:    types.StringValue("avatar_url"),
+					ApiTokenName: types.StringNull(),
+				},
+			},
+			{
+				"just id - platform_v1.BasicSubjectProfile",
+				platform_v1.BasicSubjectProfile{Id: "id"},
 				models.SubjectProfile{
 					Id:           types.StringValue("id"),
 					SubjectType:  types.StringNull(),


### PR DESCRIPTION
## Description

`SubjectProfileTypesObject` dereferenced a typed-nil `*iam.BasicSubjectProfile` without a
guard, crashing the provider on any Team whose `updatedBy` was absent.

Auditing the rest of the models found the same shape elsewhere, plus a second family: the
generated clients populate `JSON200` only for a JSON 200, while `NormalizeAPIError` accepts
200/201/204 — so "no error" and "no body" could both be true, and reading that nil into a
model panicked.

- **`clients.NormalizeAPIResponseWithBody`** — `NormalizeAPIError` plus a required-body check.
  `json200` is a parameter so it can't be forgotten; returns the status code so `404 →
  RemoveResource` still works. Replaces 77 call sites, including 41 hand-written nil guards.
- **Typed-nil guards** in `SubjectProfileTypesObject`, `AlertNotificationChannelsTypesSet`
  (live crash — `notificationChannels` is `omitempty`), and `AlertRulesTypesObject`.
- **`astro_user_roles` drift recovery** — a nil guard sat above the 404 check, making
  `RemoveResource` unreachable. A user deleted outside Terraform broke `plan` permanently
  with no fix but manual state surgery.
- **`organization_role`** is `Required`, so a missing one now errors instead of writing a
  null that surfaces as "inconsistent result after apply" (`user_roles` + `team_roles`).
- **`astro_organization`** — `updated_by` was populated from `CreatedBy`.
- **Bulk alert create** — a bodiless or short chunk was skipped, and since IDs are zipped to
  keys by index, every later key took the wrong alert's ID. Now aborts, keeping the returned
  IDs a valid prefix.

## 🎟 Issue(s)

## 🧪 Functional Testing

Unit tests cover each fix; the bulk-create tests fail against the previous code. Build, vet,
gofmt, and the full unit suite pass.

## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->

## 📋 Checklist

- [x] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
