### PR TITLE
fail fast during tf plan state during the update of custom roles associated with a Direct access token

### DIFF
--- a/docs/data-sources/api_token.md
+++ b/docs/data-sources/api_token.md
@@ -37,6 +37,7 @@ output "api_token" {
 - `description` (String) API Token description
 - `end_at` (String) time when the API token will expire in UTC
 - `expiry_period_in_days` (Number) API Token expiry period in days
+- `kind` (String) API Token kind (STANDARD or DIRECT_ACCESS)
 - `last_used_at` (String) API Token last used timestamp
 - `name` (String) API Token name
 - `roles` (Attributes Set) The roles assigned to the API Token (see [below for nested schema](#nestedatt--roles))

--- a/docs/data-sources/api_tokens.md
+++ b/docs/data-sources/api_tokens.md
@@ -60,6 +60,7 @@ Read-Only:
 - `description` (String) API Token description
 - `end_at` (String) time when the API token will expire in UTC
 - `expiry_period_in_days` (Number) API Token expiry period in days
+- `kind` (String) API Token kind (STANDARD or DIRECT_ACCESS)
 - `last_used_at` (String) API Token last used timestamp
 - `name` (String) API Token name
 - `roles` (Attributes Set) The roles assigned to the API Token (see [below for nested schema](#nestedatt--api_tokens--roles))

--- a/docs/resources/api_token.md
+++ b/docs/resources/api_token.md
@@ -170,6 +170,7 @@ resource "astro_api_token" "imported_api_token" {
 - `created_by` (Attributes) API Token creator (see [below for nested schema](#nestedatt--created_by))
 - `end_at` (String) time when the API token will expire in UTC
 - `id` (String) API Token identifier
+- `kind` (String) API Token kind (STANDARD or DIRECT_ACCESS). This resource always creates STANDARD tokens.
 - `last_used_at` (String) API Token last used timestamp
 - `short_token` (String) API Token short token
 - `start_at` (String) time when the API token will become valid in UTC

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/samber/lo v1.39.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/sync v0.8.0
 )
 
 require (
@@ -90,7 +91,6 @@ require (
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect

--- a/internal/provider/models/api_token.go
+++ b/internal/provider/models/api_token.go
@@ -17,6 +17,7 @@ type ApiTokenDataSource struct {
 	Description        types.String `tfsdk:"description"`
 	ShortToken         types.String `tfsdk:"short_token"`
 	Type               types.String `tfsdk:"type"`
+	Kind               types.String `tfsdk:"kind"`
 	StartAt            types.String `tfsdk:"start_at"`
 	EndAt              types.String `tfsdk:"end_at"`
 	CreatedAt          types.String `tfsdk:"created_at"`
@@ -35,6 +36,7 @@ type ApiTokenResource struct {
 	Description        types.String `tfsdk:"description"`
 	ShortToken         types.String `tfsdk:"short_token"`
 	Type               types.String `tfsdk:"type"`
+	Kind               types.String `tfsdk:"kind"`
 	StartAt            types.String `tfsdk:"start_at"`
 	EndAt              types.String `tfsdk:"end_at"`
 	CreatedAt          types.String `tfsdk:"created_at"`
@@ -54,6 +56,7 @@ func (data *ApiTokenDataSource) ReadFromResponse(ctx context.Context, apiToken *
 	data.Description = types.StringValue(apiToken.Description)
 	data.ShortToken = types.StringValue(apiToken.ShortToken)
 	data.Type = types.StringValue(string(apiToken.Type))
+	data.Kind = types.StringValue(string(apiToken.Kind))
 	data.StartAt = types.StringValue(apiToken.StartAt.String())
 	if apiToken.EndAt != nil {
 		data.EndAt = types.StringValue(apiToken.EndAt.String())
@@ -98,6 +101,7 @@ func (data *ApiTokenResource) ReadFromResponse(ctx context.Context, apiToken *ia
 	}
 	data.ShortToken = types.StringValue(apiToken.ShortToken)
 	data.Type = types.StringValue(string(apiToken.Type))
+	data.Kind = types.StringValue(string(apiToken.Kind))
 	data.StartAt = types.StringValue(apiToken.StartAt.String())
 	if apiToken.EndAt == nil {
 		data.EndAt = types.StringNull()

--- a/internal/provider/resources/resource_custom_role.go
+++ b/internal/provider/resources/resource_custom_role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/astronomer/terraform-provider-astro/internal/clients"
 	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
@@ -21,6 +22,10 @@ import (
 var _ resource.Resource = &customRoleResource{}
 var _ resource.ResourceWithImportState = &customRoleResource{}
 var _ resource.ResourceWithConfigure = &customRoleResource{}
+var _ resource.ResourceWithModifyPlan = &customRoleResource{}
+
+// maxListedTokensInDiagnostic caps how many tokens are named in the ModifyPlan error.
+const maxListedTokensInDiagnostic = 10
 
 func NewCustomRoleResource() resource.Resource {
 	return &customRoleResource{}
@@ -70,6 +75,139 @@ func (r *customRoleResource) Configure(
 
 	r.IamClient = apiClients.IamClient
 	r.OrganizationId = apiClients.OrganizationId
+}
+
+// ModifyPlan surfaces role/Direct Access Token permission conflicts at plan time instead of
+// a confusing failure at apply.
+func (r *customRoleResource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var state, plan models.CustomRoleResource
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.Permissions.Equal(plan.Permissions) {
+		return
+	}
+
+	if r.IamClient == nil {
+		return
+	}
+
+	roleId := state.Id.ValueString()
+	roleName := state.Name.ValueString()
+	// Token role assignments reference the role by name, not by ID.
+	conflictingTokens, err := findDirectAccessTokensUsingRole(ctx, r.IamClient, r.OrganizationId, roleName)
+	if err != nil {
+		tflog.Warn(ctx, "failed to check for Direct Access Tokens attached to custom role", map[string]interface{}{"error": err})
+		return
+	}
+	if len(conflictingTokens) == 0 {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("permissions"),
+		"Custom role has Direct Access Tokens attached",
+		fmt.Sprintf(
+			"Custom role %q (id: %s) is referenced by %d Direct Access Token(s): %s. "+
+				"Direct Access Tokens capture a role's permissions at creation time, so the API rejects permission "+
+				"changes to a role while any Direct Access Token references it, and this apply would fail. "+
+				"Delete and recreate the affected token(s) (outside of Terraform, e.g. with `astro deployment token`) "+
+				"so they pick up the new permissions, then re-apply this change.",
+			roleName, roleId, len(conflictingTokens), formatTokenListForDiagnostic(conflictingTokens),
+		),
+	)
+}
+
+// findDirectAccessTokensUsingRole returns the org's Direct Access Tokens assigned roleName.
+// The list endpoint can't filter by role and omits `roles`, so each candidate is re-fetched.
+func findDirectAccessTokensUsingRole(
+	ctx context.Context,
+	client *iam.ClientWithResponses,
+	organizationId string,
+	roleName string,
+) ([]iam.ApiToken, error) {
+	var candidateIds []string
+
+	params := &iam.ListApiTokensParams{
+		Kind:  lo.ToPtr(iam.DIRECTACCESS),
+		Limit: lo.ToPtr(1000),
+	}
+	offset := 0
+	for {
+		params.Offset = &offset
+		tokensResp, err := client.ListApiTokensWithResponse(ctx, organizationId, params)
+		if err != nil {
+			return nil, err
+		}
+		if tokensResp.JSON200 == nil {
+			return nil, fmt.Errorf("unable to list Direct Access Tokens, got status %v", tokensResp.StatusCode())
+		}
+
+		for _, token := range tokensResp.JSON200.Tokens {
+			candidateIds = append(candidateIds, token.Id)
+		}
+
+		if tokensResp.JSON200.TotalCount <= offset {
+			break
+		}
+		offset += 1000
+	}
+
+	var matches []iam.ApiToken
+	for _, tokenId := range candidateIds {
+		tokenResp, err := client.GetApiTokenWithResponse(ctx, organizationId, tokenId)
+		if err != nil {
+			return nil, err
+		}
+		if tokenResp.JSON200 == nil {
+			return nil, fmt.Errorf("unable to get Direct Access Token %s, got status %v", tokenId, tokenResp.StatusCode())
+		}
+
+		token := tokenResp.JSON200
+		if token.Roles == nil {
+			continue
+		}
+		for _, tokenRole := range *token.Roles {
+			if tokenRole.Role == roleName {
+				matches = append(matches, *token)
+				break
+			}
+		}
+	}
+
+	return matches, nil
+}
+
+// formatTokenListForDiagnostic renders a length-capped, human-readable list of tokens.
+func formatTokenListForDiagnostic(tokens []iam.ApiToken) string {
+	shown := tokens
+	truncated := 0
+	if len(shown) > maxListedTokensInDiagnostic {
+		shown = tokens[:maxListedTokensInDiagnostic]
+		truncated = len(tokens) - maxListedTokensInDiagnostic
+	}
+
+	names := make([]string, 0, len(shown))
+	for _, token := range shown {
+		names = append(names, fmt.Sprintf("%s (id: %s)", token.Name, token.Id))
+	}
+
+	list := strings.Join(names, ", ")
+	if truncated > 0 {
+		list = fmt.Sprintf("%s, and %d more", list, truncated)
+	}
+	return list
 }
 
 func (r *customRoleResource) Create(

--- a/internal/provider/resources/resource_custom_role.go
+++ b/internal/provider/resources/resource_custom_role.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/astronomer/terraform-provider-astro/internal/clients"
 	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
@@ -16,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -24,8 +27,12 @@ var _ resource.ResourceWithImportState = &customRoleResource{}
 var _ resource.ResourceWithConfigure = &customRoleResource{}
 var _ resource.ResourceWithModifyPlan = &customRoleResource{}
 
-// maxListedTokensInDiagnostic caps how many tokens are named in the ModifyPlan error.
-const maxListedTokensInDiagnostic = 10
+const (
+	maxListedTokensInDiagnostic        = 10
+	directAccessTokenLookupTimeout     = 10 * time.Second
+	directAccessTokenListPageSize      = 1000
+	directAccessTokenLookupConcurrency = 8
+)
 
 func NewCustomRoleResource() resource.Resource {
 	return &customRoleResource{}
@@ -77,8 +84,7 @@ func (r *customRoleResource) Configure(
 	r.OrganizationId = apiClients.OrganizationId
 }
 
-// ModifyPlan surfaces role/Direct Access Token permission conflicts at plan time instead of
-// a confusing failure at apply.
+// ModifyPlan catches role/Direct Access Token permission conflicts at plan time.
 func (r *customRoleResource) ModifyPlan(
 	ctx context.Context,
 	req resource.ModifyPlanRequest,
@@ -105,10 +111,21 @@ func (r *customRoleResource) ModifyPlan(
 
 	roleId := state.Id.ValueString()
 	roleName := state.Name.ValueString()
-	// Token role assignments reference the role by name, not by ID.
-	conflictingTokens, err := findDirectAccessTokensUsingRole(ctx, r.IamClient, r.OrganizationId, roleName)
+
+	lookupCtx, cancel := context.WithTimeout(ctx, directAccessTokenLookupTimeout)
+	defer cancel()
+
+	conflictingTokens, err := findDirectAccessTokensUsingRole(lookupCtx, r.IamClient, r.OrganizationId, roleName)
 	if err != nil {
 		tflog.Warn(ctx, "failed to check for Direct Access Tokens attached to custom role", map[string]interface{}{"error": err})
+		resp.Diagnostics.AddWarning(
+			"Unable to verify Direct Access Token compatibility",
+			fmt.Sprintf(
+				"Could not check whether custom role %q is referenced by any Direct Access Tokens before applying this change: %s. "+
+					"If it is, this apply will fail with an error from the API instead of being caught here.",
+				roleName, err,
+			),
+		)
 		return
 	}
 	if len(conflictingTokens) == 0 {
@@ -129,19 +146,33 @@ func (r *customRoleResource) ModifyPlan(
 	)
 }
 
-// findDirectAccessTokensUsingRole returns the org's Direct Access Tokens assigned roleName.
-// The list endpoint can't filter by role and omits `roles`, so each candidate is re-fetched.
 func findDirectAccessTokensUsingRole(
 	ctx context.Context,
 	client *iam.ClientWithResponses,
 	organizationId string,
 	roleName string,
 ) ([]iam.ApiToken, error) {
+	return findDirectAccessTokensUsingRoleWithLimits(
+		ctx, client, organizationId, roleName,
+		directAccessTokenListPageSize, directAccessTokenLookupConcurrency,
+	)
+}
+
+// The list endpoint can't filter by role and omits `roles`, so tokens are listed, then
+// re-fetched individually (up to concurrency at a time) to check role assignments.
+func findDirectAccessTokensUsingRoleWithLimits(
+	ctx context.Context,
+	client *iam.ClientWithResponses,
+	organizationId string,
+	roleName string,
+	pageSize int,
+	concurrency int,
+) ([]iam.ApiToken, error) {
 	var candidateIds []string
 
 	params := &iam.ListApiTokensParams{
 		Kind:  lo.ToPtr(iam.DIRECTACCESS),
-		Limit: lo.ToPtr(1000),
+		Limit: lo.ToPtr(pageSize),
 	}
 	offset := 0
 	for {
@@ -161,29 +192,42 @@ func findDirectAccessTokensUsingRole(
 		if tokensResp.JSON200.TotalCount <= offset {
 			break
 		}
-		offset += 1000
+		offset += pageSize
 	}
 
-	var matches []iam.ApiToken
+	var (
+		mu      sync.Mutex
+		matches []iam.ApiToken
+	)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
 	for _, tokenId := range candidateIds {
-		tokenResp, err := client.GetApiTokenWithResponse(ctx, organizationId, tokenId)
-		if err != nil {
-			return nil, err
-		}
-		if tokenResp.JSON200 == nil {
-			return nil, fmt.Errorf("unable to get Direct Access Token %s, got status %v", tokenId, tokenResp.StatusCode())
-		}
-
-		token := tokenResp.JSON200
-		if token.Roles == nil {
-			continue
-		}
-		for _, tokenRole := range *token.Roles {
-			if tokenRole.Role == roleName {
-				matches = append(matches, *token)
-				break
+		g.Go(func() error {
+			tokenResp, err := client.GetApiTokenWithResponse(gctx, organizationId, tokenId)
+			if err != nil {
+				return err
 			}
-		}
+			if tokenResp.JSON200 == nil {
+				return fmt.Errorf("unable to get Direct Access Token %s, got status %v", tokenId, tokenResp.StatusCode())
+			}
+
+			token := tokenResp.JSON200
+			if token.Roles == nil {
+				return nil
+			}
+			for _, tokenRole := range *token.Roles {
+				if tokenRole.Role == roleName {
+					mu.Lock()
+					matches = append(matches, *token)
+					mu.Unlock()
+					break
+				}
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return matches, nil

--- a/internal/provider/resources/resource_custom_role_test.go
+++ b/internal/provider/resources/resource_custom_role_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -181,6 +182,104 @@ func TestAcc_CustomRoleRemovedOutsideOfTerraform(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAcc_ResourceCustomRoleDirectAccessTokenConflict verifies that changing the permissions
+// of a custom role that is referenced by a Direct Access Token fails during `terraform plan`
+// (via ModifyPlan) rather than surfacing only as a confusing apply-time API error. Direct
+// Access Tokens are created outside of Terraform (the astro_api_token resource cannot create
+// them), so the conflicting token is created directly via the IAM client.
+func TestAcc_ResourceCustomRoleDirectAccessTokenConflict(t *testing.T) {
+	customRoleName := utils.GenerateTestResourceName(10)
+	deploymentId := os.Getenv("HOSTED_DEPLOYMENT_ID")
+	organizationId := os.Getenv("HOSTED_ORGANIZATION_ID")
+
+	var directAccessTokenId string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckCustomRoleExistence(t, customRoleName, false),
+			testAccDeleteDirectAccessTokenIfExists(t, &directAccessTokenId),
+		),
+		Steps: []resource.TestStep{
+			// Create the custom role, then attach a Direct Access Token to it outside of Terraform.
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + customRole("test", customRoleName, utils.TestResourceDescription, "DEPLOYMENT", []string{"deployment.get"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCustomRoleExistence(t, customRoleName, true),
+					testAccCreateDirectAccessTokenForRole(t, organizationId, deploymentId, customRoleName, &directAccessTokenId),
+				),
+			},
+			// Adding a permission to the role should now fail at plan time, not apply time.
+			{
+				Config:      astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + customRole("test", customRoleName, utils.TestResourceDescription, "DEPLOYMENT", []string{"deployment.get", "deployment.update"}),
+				ExpectError: regexp.MustCompile("Custom role has Direct Access Tokens attached"),
+			},
+		},
+	})
+}
+
+// testAccCreateDirectAccessTokenForRole creates a Direct Access Token scoped to deploymentId
+// and assigned to the named custom role, bypassing Terraform (mirroring how a customer would
+// create one via `astro deployment token create --direct-access` or the UI).
+func testAccCreateDirectAccessTokenForRole(t *testing.T, organizationId, deploymentId, customRoleName string, tokenId *string) func(state *terraform.State) error {
+	t.Helper()
+	return func(state *terraform.State) error {
+		client, err := utils.GetTestHostedIamClient()
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		rolesResp, err := client.ListRolesWithResponse(ctx, organizationId, &iam.ListRolesParams{})
+		if err != nil {
+			return fmt.Errorf("failed to list roles: %w", err)
+		}
+		var customRoleId string
+		if rolesResp.JSON200 != nil {
+			for _, role := range rolesResp.JSON200.Roles {
+				if role.Name == customRoleName {
+					customRoleId = role.Id
+					break
+				}
+			}
+		}
+		if customRoleId == "" {
+			return fmt.Errorf("custom role %s should exist but list roles did not find it", customRoleName)
+		}
+
+		createResp, err := client.CreateApiTokenWithResponse(ctx, organizationId, iam.CreateApiTokenRequest{
+			Name:     fmt.Sprintf("%s-dat", customRoleName),
+			Type:     iam.CreateApiTokenRequestTypeDEPLOYMENT,
+			EntityId: &deploymentId,
+			Role:     customRoleId,
+			Kind:     lo.ToPtr(iam.CreateApiTokenRequestKind(iam.ApiTokenKindDIRECTACCESS)),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create Direct Access Token: %w", err)
+		}
+		if createResp.JSON200 == nil {
+			status, diagnostic := clients.NormalizeAPIError(ctx, createResp.HTTPResponse, createResp.Body)
+			return fmt.Errorf("failed to create Direct Access Token, status: %v, err: %v", status, diagnostic.Detail())
+		}
+		*tokenId = createResp.JSON200.Id
+		return nil
+	}
+}
+
+func testAccDeleteDirectAccessTokenIfExists(t *testing.T, tokenId *string) func(state *terraform.State) error {
+	t.Helper()
+	return func(state *terraform.State) error {
+		if tokenId == nil || *tokenId == "" {
+			return nil
+		}
+		client, err := utils.GetTestHostedIamClient()
+		assert.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = client.DeleteApiTokenWithResponse(ctx, os.Getenv("HOSTED_ORGANIZATION_ID"), *tokenId)
+		return err
+	}
 }
 
 func customRoleWithVariableName() string {

--- a/internal/provider/resources/resource_custom_role_test.go
+++ b/internal/provider/resources/resource_custom_role_test.go
@@ -231,28 +231,13 @@ func testAccCreateDirectAccessTokenForRole(t *testing.T, organizationId, deploym
 		assert.NoError(t, err)
 
 		ctx := context.Background()
-		rolesResp, err := client.ListRolesWithResponse(ctx, organizationId, &iam.ListRolesParams{})
-		if err != nil {
-			return fmt.Errorf("failed to list roles: %w", err)
-		}
-		var customRoleId string
-		if rolesResp.JSON200 != nil {
-			for _, role := range rolesResp.JSON200.Roles {
-				if role.Name == customRoleName {
-					customRoleId = role.Id
-					break
-				}
-			}
-		}
-		if customRoleId == "" {
-			return fmt.Errorf("custom role %s should exist but list roles did not find it", customRoleName)
-		}
-
+		// CreateApiTokenRequest.Role takes the role's name, not its ID (token role
+		// assignments are keyed by role name, matching what ApiTokenRole.Role returns).
 		createResp, err := client.CreateApiTokenWithResponse(ctx, organizationId, iam.CreateApiTokenRequest{
 			Name:     fmt.Sprintf("%s-dat", customRoleName),
 			Type:     iam.CreateApiTokenRequestTypeDEPLOYMENT,
 			EntityId: &deploymentId,
-			Role:     customRoleId,
+			Role:     customRoleName,
 			Kind:     lo.ToPtr(iam.CreateApiTokenRequestKind(iam.ApiTokenKindDIRECTACCESS)),
 		})
 		if err != nil {

--- a/internal/provider/resources/resource_custom_role_test.go
+++ b/internal/provider/resources/resource_custom_role_test.go
@@ -199,10 +199,7 @@ func TestAcc_ResourceCustomRoleDirectAccessTokenConflict(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckCustomRoleExistence(t, customRoleName, false),
-			testAccDeleteDirectAccessTokenIfExists(t, &directAccessTokenId),
-		),
+		CheckDestroy: testAccCheckCustomRoleExistence(t, customRoleName, false),
 		Steps: []resource.TestStep{
 			// Create the custom role, then attach a Direct Access Token to it outside of Terraform.
 			{
@@ -216,6 +213,13 @@ func TestAcc_ResourceCustomRoleDirectAccessTokenConflict(t *testing.T) {
 			{
 				Config:      astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + customRole("test", customRoleName, utils.TestResourceDescription, "DEPLOYMENT", []string{"deployment.get", "deployment.update"}),
 				ExpectError: regexp.MustCompile("Custom role has Direct Access Tokens attached"),
+			},
+			// No-op step (state is unchanged from step 1 since step 2 failed at plan) that
+			// deletes the out-of-band token before Terraform's end-of-test destroy runs,
+			// since the API also refuses to delete a role that a token still references.
+			{
+				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + customRole("test", customRoleName, utils.TestResourceDescription, "DEPLOYMENT", []string{"deployment.get"}),
+				Check:  testAccDeleteDirectAccessTokenIfExists(t, &directAccessTokenId),
 			},
 		},
 	})

--- a/internal/provider/resources/resource_custom_role_test.go
+++ b/internal/provider/resources/resource_custom_role_test.go
@@ -199,7 +199,7 @@ func TestAcc_ResourceCustomRoleDirectAccessTokenConflict(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
-		CheckDestroy: testAccCheckCustomRoleExistence(t, customRoleName, false),
+		CheckDestroy:             testAccCheckCustomRoleExistence(t, customRoleName, false),
 		Steps: []resource.TestStep{
 			// Create the custom role, then attach a Direct Access Token to it outside of Terraform.
 			{

--- a/internal/provider/resources/resource_custom_role_test.go
+++ b/internal/provider/resources/resource_custom_role_test.go
@@ -184,24 +184,24 @@ func TestAcc_CustomRoleRemovedOutsideOfTerraform(t *testing.T) {
 	})
 }
 
-// TestAcc_ResourceCustomRoleDirectAccessTokenConflict verifies that changing the permissions
-// of a custom role that is referenced by a Direct Access Token fails during `terraform plan`
-// (via ModifyPlan) rather than surfacing only as a confusing apply-time API error. Direct
-// Access Tokens are created outside of Terraform (the astro_api_token resource cannot create
-// them), so the conflicting token is created directly via the IAM client.
+// TestAcc_ResourceCustomRoleDirectAccessTokenConflict verifies that changing a custom role's
+// permissions while a Direct Access Token references it fails at plan time, not apply time.
 func TestAcc_ResourceCustomRoleDirectAccessTokenConflict(t *testing.T) {
 	customRoleName := utils.GenerateTestResourceName(10)
 	deploymentId := os.Getenv("HOSTED_DEPLOYMENT_ID")
 	organizationId := os.Getenv("HOSTED_ORGANIZATION_ID")
 
 	var directAccessTokenId string
+	// Safety net in case the guard regresses and skips the normal cleanup step below.
+	t.Cleanup(func() {
+		testAccForceCleanupDirectAccessTokenAndRole(t, organizationId, &directAccessTokenId, customRoleName)
+	})
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: astronomerprovider.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { astronomerprovider.TestAccPreCheck(t) },
 		CheckDestroy:             testAccCheckCustomRoleExistence(t, customRoleName, false),
 		Steps: []resource.TestStep{
-			// Create the custom role, then attach a Direct Access Token to it outside of Terraform.
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + customRole("test", customRoleName, utils.TestResourceDescription, "DEPLOYMENT", []string{"deployment.get"}),
 				Check: resource.ComposeTestCheckFunc(
@@ -209,14 +209,11 @@ func TestAcc_ResourceCustomRoleDirectAccessTokenConflict(t *testing.T) {
 					testAccCreateDirectAccessTokenForRole(t, organizationId, deploymentId, customRoleName, &directAccessTokenId),
 				),
 			},
-			// Adding a permission to the role should now fail at plan time, not apply time.
 			{
 				Config:      astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + customRole("test", customRoleName, utils.TestResourceDescription, "DEPLOYMENT", []string{"deployment.get", "deployment.update"}),
 				ExpectError: regexp.MustCompile("Custom role has Direct Access Tokens attached"),
 			},
-			// No-op step (state is unchanged from step 1 since step 2 failed at plan) that
-			// deletes the out-of-band token before Terraform's end-of-test destroy runs,
-			// since the API also refuses to delete a role that a token still references.
+			// No-op step: deletes the out-of-band token so the role can be destroyed cleanly.
 			{
 				Config: astronomerprovider.ProviderConfig(t, astronomerprovider.HOSTED) + customRole("test", customRoleName, utils.TestResourceDescription, "DEPLOYMENT", []string{"deployment.get"}),
 				Check:  testAccDeleteDirectAccessTokenIfExists(t, &directAccessTokenId),
@@ -225,9 +222,8 @@ func TestAcc_ResourceCustomRoleDirectAccessTokenConflict(t *testing.T) {
 	})
 }
 
-// testAccCreateDirectAccessTokenForRole creates a Direct Access Token scoped to deploymentId
-// and assigned to the named custom role, bypassing Terraform (mirroring how a customer would
-// create one via `astro deployment token create --direct-access` or the UI).
+// testAccCreateDirectAccessTokenForRole creates a Direct Access Token outside of Terraform,
+// scoped to deploymentId and assigned to customRoleName.
 func testAccCreateDirectAccessTokenForRole(t *testing.T, organizationId, deploymentId, customRoleName string, tokenId *string) func(state *terraform.State) error {
 	t.Helper()
 	return func(state *terraform.State) error {
@@ -235,8 +231,7 @@ func testAccCreateDirectAccessTokenForRole(t *testing.T, organizationId, deploym
 		assert.NoError(t, err)
 
 		ctx := context.Background()
-		// CreateApiTokenRequest.Role takes the role's name, not its ID (token role
-		// assignments are keyed by role name, matching what ApiTokenRole.Role returns).
+		// Role takes the role's name, not its ID.
 		createResp, err := client.CreateApiTokenWithResponse(ctx, organizationId, iam.CreateApiTokenRequest{
 			Name:     fmt.Sprintf("%s-dat", customRoleName),
 			Type:     iam.CreateApiTokenRequestTypeDEPLOYMENT,
@@ -253,6 +248,31 @@ func testAccCreateDirectAccessTokenForRole(t *testing.T, organizationId, deploym
 		}
 		*tokenId = createResp.JSON200.Id
 		return nil
+	}
+}
+
+// testAccForceCleanupDirectAccessTokenAndRole best-effort deletes the token and role directly.
+func testAccForceCleanupDirectAccessTokenAndRole(t *testing.T, organizationId string, tokenId *string, roleName string) {
+	t.Helper()
+	client, err := utils.GetTestHostedIamClient()
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+	if tokenId != nil && *tokenId != "" {
+		_, _ = client.DeleteApiTokenWithResponse(ctx, organizationId, *tokenId)
+	}
+
+	rolesResp, err := client.ListRolesWithResponse(ctx, organizationId, &iam.ListRolesParams{})
+	if err != nil || rolesResp.JSON200 == nil {
+		return
+	}
+	for _, role := range rolesResp.JSON200.Roles {
+		if role.Name == roleName {
+			_, _ = client.DeleteCustomRoleWithResponse(ctx, organizationId, role.Id)
+			return
+		}
 	}
 }
 

--- a/internal/provider/resources/resource_custom_role_unit_test.go
+++ b/internal/provider/resources/resource_custom_role_unit_test.go
@@ -1,0 +1,199 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/astronomer/terraform-provider-astro/internal/clients/iam"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTokensServer stands in for the IAM ListApiTokens/GetApiToken endpoints.
+type fakeTokensServer struct {
+	mu         sync.Mutex
+	tokens     []iam.ApiToken
+	listDelay  time.Duration
+	listBroken bool
+}
+
+func newFakeTokensServer(t *testing.T, tokens []iam.ApiToken) (*httptest.Server, *fakeTokensServer) {
+	t.Helper()
+	fake := &fakeTokensServer{tokens: tokens}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fake.mu.Lock()
+		delay, broken, allTokens := fake.listDelay, fake.listBroken, fake.tokens
+		fake.mu.Unlock()
+
+		segments := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		tokensIdx := -1
+		for i, s := range segments {
+			if s == "tokens" {
+				tokensIdx = i
+				break
+			}
+		}
+		if tokensIdx == -1 {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if tokensIdx < len(segments)-1 {
+			tokenId := segments[tokensIdx+1]
+			for _, tok := range allTokens {
+				if tok.Id == tokenId {
+					_ = json.NewEncoder(w).Encode(tok)
+					return
+				}
+			}
+			http.NotFound(w, r)
+			return
+		}
+
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-r.Context().Done():
+				return
+			}
+		}
+		if broken {
+			_, _ = w.Write([]byte("{not valid json"))
+			return
+		}
+
+		limit, offset := 1000, 0
+		if v := r.URL.Query().Get("limit"); v != "" {
+			limit, _ = strconv.Atoi(v)
+		}
+		if v := r.URL.Query().Get("offset"); v != "" {
+			offset, _ = strconv.Atoi(v)
+		}
+
+		var page []iam.ApiToken
+		if offset < len(allTokens) {
+			page = allTokens[offset:min(offset+limit, len(allTokens))]
+		}
+
+		_ = json.NewEncoder(w).Encode(iam.ApiTokensPaginated{
+			Tokens:     page,
+			Limit:      limit,
+			Offset:     offset,
+			TotalCount: len(allTokens),
+		})
+	}))
+	return srv, fake
+}
+
+func fakeDirectAccessToken(id, name string, roles ...string) iam.ApiToken {
+	tok := iam.ApiToken{Id: id, Name: name, Kind: iam.ApiTokenKindDIRECTACCESS}
+	if len(roles) > 0 {
+		apiRoles := make([]iam.ApiTokenRole, 0, len(roles))
+		for _, r := range roles {
+			apiRoles = append(apiRoles, iam.ApiTokenRole{Role: r})
+		}
+		tok.Roles = &apiRoles
+	}
+	return tok
+}
+
+func TestUnit_FindDirectAccessTokensUsingRole_NoMatches(t *testing.T) {
+	srv, _ := newFakeTokensServer(t, []iam.ApiToken{
+		fakeDirectAccessToken("tok-1", "one", "OtherRole"),
+		fakeDirectAccessToken("tok-2", "two"),
+	})
+	defer srv.Close()
+
+	client, err := iam.NewIamClient(srv.URL, "token", "test")
+	require.NoError(t, err)
+
+	matches, err := findDirectAccessTokensUsingRoleWithLimits(context.Background(), client, "org", "TargetRole", 1000, 4)
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
+func TestUnit_FindDirectAccessTokensUsingRole_MatchesAcrossPages(t *testing.T) {
+	srv, _ := newFakeTokensServer(t, []iam.ApiToken{
+		fakeDirectAccessToken("tok-0", "zero", "OtherRole"),
+		fakeDirectAccessToken("tok-1", "one"),
+		fakeDirectAccessToken("tok-2", "two", "AnotherRole"),
+		fakeDirectAccessToken("tok-3", "three", "TargetRole"),
+		fakeDirectAccessToken("tok-4", "four"),
+	})
+	defer srv.Close()
+
+	client, err := iam.NewIamClient(srv.URL, "token", "test")
+	require.NoError(t, err)
+
+	matches, err := findDirectAccessTokensUsingRoleWithLimits(context.Background(), client, "org", "TargetRole", 2, 4)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "tok-3", matches[0].Id)
+}
+
+func TestUnit_FindDirectAccessTokensUsingRole_ListErrorFailsOpen(t *testing.T) {
+	srv, fake := newFakeTokensServer(t, []iam.ApiToken{fakeDirectAccessToken("tok-1", "one", "TargetRole")})
+	defer srv.Close()
+	fake.mu.Lock()
+	fake.listBroken = true
+	fake.mu.Unlock()
+
+	client, err := iam.NewIamClient(srv.URL, "token", "test")
+	require.NoError(t, err)
+
+	_, err = findDirectAccessTokensUsingRoleWithLimits(context.Background(), client, "org", "TargetRole", 1000, 4)
+	assert.Error(t, err)
+}
+
+func TestUnit_FindDirectAccessTokensUsingRole_RespectsTimeout(t *testing.T) {
+	srv, fake := newFakeTokensServer(t, []iam.ApiToken{fakeDirectAccessToken("tok-1", "one", "TargetRole")})
+	defer srv.Close()
+	fake.mu.Lock()
+	fake.listDelay = 500 * time.Millisecond
+	fake.mu.Unlock()
+
+	client, err := iam.NewIamClient(srv.URL, "token", "test")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err = findDirectAccessTokensUsingRoleWithLimits(ctx, client, "org", "TargetRole", 1000, 4)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.Less(t, elapsed, 400*time.Millisecond, "lookup should abort on context timeout, not wait for the slow response")
+}
+
+func TestUnit_FormatTokenListForDiagnostic_TruncatesAtTen(t *testing.T) {
+	var tokens []iam.ApiToken
+	for i := range 12 {
+		tokens = append(tokens, fakeDirectAccessToken(fmt.Sprintf("tok-%d", i), fmt.Sprintf("name-%d", i)))
+	}
+
+	result := formatTokenListForDiagnostic(tokens)
+
+	assert.Contains(t, result, "name-0 (id: tok-0)")
+	assert.Contains(t, result, "name-9 (id: tok-9)")
+	assert.NotContains(t, result, "name-10")
+	assert.Contains(t, result, "and 2 more")
+}
+
+func TestUnit_FormatTokenListForDiagnostic_NoTruncationUnderLimit(t *testing.T) {
+	tokens := []iam.ApiToken{fakeDirectAccessToken("tok-1", "one"), fakeDirectAccessToken("tok-2", "two")}
+
+	result := formatTokenListForDiagnostic(tokens)
+
+	assert.Equal(t, "one (id: tok-1), two (id: tok-2)", result)
+}

--- a/internal/provider/schemas/api_token.go
+++ b/internal/provider/schemas/api_token.go
@@ -35,6 +35,10 @@ func ApiTokenDataSourceSchemaAttributes() map[string]datasourceSchema.Attribute 
 			MarkdownDescription: "API Token type",
 			Computed:            true,
 		},
+		"kind": datasourceSchema.StringAttribute{
+			MarkdownDescription: "API Token kind (STANDARD or DIRECT_ACCESS)",
+			Computed:            true,
+		},
 		"start_at": datasourceSchema.StringAttribute{
 			MarkdownDescription: "time when the API token will become valid in UTC",
 			Computed:            true,
@@ -111,6 +115,13 @@ func ApiTokenResourceSchemaAttributes() map[string]resourceSchema.Attribute {
 			},
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplaceIfConfigured(),
+			},
+		},
+		"kind": resourceSchema.StringAttribute{
+			MarkdownDescription: "API Token kind (STANDARD or DIRECT_ACCESS). This resource always creates STANDARD tokens.",
+			Computed:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"start_at": resourceSchema.StringAttribute{

--- a/internal/provider/schemas/api_tokens.go
+++ b/internal/provider/schemas/api_tokens.go
@@ -15,6 +15,7 @@ func ApiTokensElementAttributeTypes() map[string]attr.Type {
 		"description": types.StringType,
 		"short_token": types.StringType,
 		"type":        types.StringType,
+		"kind":        types.StringType,
 		"start_at":    types.StringType,
 		"end_at":      types.StringType,
 		"created_at":  types.StringType,


### PR DESCRIPTION

## Description

Currently adding a permission to an existing deployment-scoped `astro_custom_role` passed `terraform plan` cleanly but failed at `terraform apply`, with no indication in the plan that anything was wrong. Root
  cause: the role had one or more Direct Access Tokens (DATs) attached, and DATs snapshot their role's permissions at creation time, the API rejects permission changes to a role while any DAT references it. Nothing in local state/config
  diffing can see this, so it silently passed plan and only surfaced as a generic 400 at apply.

  This PR:

  - Fails fast at plan time. Adds a `ModifyPlan` check on `astro_custom_role`: when `permissions` changes, the provider looks up whether any Direct Access Token references the role (by name, since token role assignments are keyed by role
  name, not ID) and raises a clear plan-time error naming the conflicting token(s) and the required workaround, instead of letting a broken plan through. The API's own apply-time rejection is left untouched as the authoritative backstop, since
  state can still drift between plan and apply.
  - Surfaces token kind. Adds `kind` (`STANDARD` / `DIRECT_ACCESS`) to the `astro_api_token` resource, the `astro_api_token` data source, and the `astro_api_tokens` list data source. The IAM API already returns this field, but the provider
  was silently dropping it, making it impossible to tell a DAT apart from a standard token via Terraform.

  Note: Direct Access Tokens themselves can't be created via `astro_api_token` (the API only allows creating them outside Terraform, e.g. via `astro deployment token` or the UI), so this is a best-effort provider-side safety net, not full
  lifecycle management of DATs.


## 🎟 Issue(s)
 CPP-940

## 🧪 Functional Testing

1. Created a custom role.
2. Attached it to a deployment scoped DAT.
3. Tried to add another granular permission to the role.
4. After fix, TF plan failed as expected.


## 📸 Screenshots

<!--- Add screenshots to illustrate the validity of these changes. --->
<img width="1728" height="403" alt="image" src="https://github.com/user-attachments/assets/1d320af8-6e16-4bd6-8adf-a810e5efda73" />

## 📋 Checklist

- [x] Added/updated applicable tests
- [ ] Added/updated examples in the `examples/` directory
- [ ] Updated any related [documentation](https://github.com/astronomer/docs/)
