### PR TITLE
fix: stop tracking api_token last_used_at in resource state to prevent perpetual drift

### DIFF
--- a/docs/resources/api_token.md
+++ b/docs/resources/api_token.md
@@ -170,7 +170,6 @@ resource "astro_api_token" "imported_api_token" {
 - `created_by` (Attributes) API Token creator (see [below for nested schema](#nestedatt--created_by))
 - `end_at` (String) time when the API token will expire in UTC
 - `id` (String) API Token identifier
-- `last_used_at` (String) API Token last used timestamp
 - `short_token` (String) API Token short token
 - `start_at` (String) time when the API token will become valid in UTC
 - `token` (String, Sensitive) API Token value. Warning: This value will be saved in plaintext in the terraform state file.

--- a/internal/provider/models/api_token.go
+++ b/internal/provider/models/api_token.go
@@ -42,7 +42,6 @@ type ApiTokenResource struct {
 	CreatedBy          types.Object `tfsdk:"created_by"`
 	UpdatedBy          types.Object `tfsdk:"updated_by"`
 	ExpiryPeriodInDays types.Int64  `tfsdk:"expiry_period_in_days"`
-	LastUsedAt         types.String `tfsdk:"last_used_at"`
 	Roles              types.Set    `tfsdk:"roles"`
 	Token              types.String `tfsdk:"token"`
 }
@@ -116,11 +115,6 @@ func (data *ApiTokenResource) ReadFromResponse(ctx context.Context, apiToken *ia
 	}
 	if apiToken.ExpiryPeriodInDays != nil {
 		data.ExpiryPeriodInDays = types.Int64Value(int64(*apiToken.ExpiryPeriodInDays))
-	}
-	if apiToken.LastUsedAt == nil {
-		data.LastUsedAt = types.StringNull()
-	} else {
-		data.LastUsedAt = types.StringValue(apiToken.LastUsedAt.String())
 	}
 	data.Roles, diags = utils.ObjectSet(ctx, apiToken.Roles, schemas.ApiTokenRoleAttributeTypes(), ApiTokenRoleTypesObject)
 	if diags.HasError() {

--- a/internal/provider/schemas/api_token.go
+++ b/internal/provider/schemas/api_token.go
@@ -143,10 +143,6 @@ func ApiTokenResourceSchemaAttributes() map[string]resourceSchema.Attribute {
 			MarkdownDescription: "API Token expiry period in days",
 			Optional:            true,
 		},
-		"last_used_at": resourceSchema.StringAttribute{
-			MarkdownDescription: "API Token last used timestamp",
-			Computed:            true,
-		},
 		"roles": resourceSchema.SetNestedAttribute{
 			NestedObject: resourceSchema.NestedAttributeObject{
 				Attributes: ResourceApiTokenRoleSchemaAttributes(),


### PR DESCRIPTION
## Description

`astro_api_token` exposed `last_used_at`, a computed (read-only) timestamp the Astro API bumps every time the token is used. The resource's `Read` wrote this value into state on every refresh, so **every `terraform plan` reported actively-used tokens under "Objects have changed outside of Terraform"**:

```
  # module.<...>.astro_api_token.this has changed
  ~ resource "astro_api_token" "this" {
        id           = "<token-id>"
      ~ last_used_at = "2026-09-03 14:04:23.101 +0000 UTC" -> "2026-09-03 17:22:06.747 +0000 UTC"
        name         = "my_api_token"
        # (10 unchanged attributes hidden)
    }
```

Because the attribute is computed, it never yields an actual apply change — it's pure plan noise — and it **cannot be suppressed from configuration**: `lifecycle { ignore_changes = [last_used_at] }` doesn't help because the "changed outside Terraform" note is emitted in the *refresh* phase, whereas `ignore_changes` only governs proposed *plan* updates (see hashicorp/terraform#28803). `-refresh=false` hides it but disables drift detection globally. So it needs a provider-side fix.

This PR removes `last_used_at` from the **`astro_api_token` resource** schema and model. The value is still available — and drift-free — on the **`astro_api_token` and `astro_api_tokens` data sources**, which read at plan time and don't persist it to managed-resource state.

### Note for reviewers (release sizing)
Removing a computed attribute is a schema change. The plugin framework's built-in state upgrade drops the stale `last_used_at` from existing state cleanly (no hand-written `StateUpgrader` needed). The only user-visible break is for anyone referencing `astro_api_token.<name>.last_used_at` in an expression/output — they'd switch to the data source. Flagging in case you'd like it slotted into a minor rather than a patch release.

## 🎟 Issue(s)

Fixes #338

## 🧪 Functional Testing

Repro (before): apply an `astro_api_token`, use the token at least once (e.g. an Airflow REST API / CI token), then run `terraform plan` — the token shows `last_used_at` drift under "Objects have changed outside of Terraform" on every run.

With this change:
- `go build ./...`, `go vet ./...` — clean.
- `make fmt` / `gofmt`/`goimports` — no diff.
- Unit tests for `internal/provider/{models,schemas,resources}` — pass.
- Docs regenerated with `tfplugindocs generate` (`docs/resources/api_token.md` no longer lists `last_used_at`; the data-source docs are unchanged).
- Manual: `terraform plan` on an unchanged, actively-used `astro_api_token` is now clean — no refresh-phase drift.

## 📸 Screenshots

N/A

## 📋 Checklist

- [x] Added/updated applicable tests — no test change required; existing `data_source_api_token` acceptance test still asserts `last_used_at` on the data source, which is unaffected. No resource test referenced the attribute.
- [ ] Added/updated examples in the `examples/` directory — N/A (no example referenced `last_used_at`).
- [x] Updated any related documentation — `docs/resources/api_token.md` regenerated via `tfplugindocs`.
