### PR TITLE
feat(deployment): support the disaster recovery workload identity

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -44,6 +44,7 @@ output "deployment" {
 - `default_task_pod_memory` (String) Deployment default task pod memory
 - `description` (String) Deployment description
 - `desired_dag_tarball_version` (String) Deployment desired DAG tarball version
+- `dr_workload_identity` (String) Deployment disaster recovery workload identity
 - `environment_variables` (Attributes Set) Deployment environment variables (see [below for nested schema](#nestedatt--environment_variables))
 - `executor` (String) Deployment executor. Allowed values: `CELERY`, `KUBERNETES`, `ASTRO`.
 - `external_ips` (Set of String) Deployment external IPs

--- a/docs/data-sources/deployments.md
+++ b/docs/data-sources/deployments.md
@@ -67,6 +67,7 @@ Read-Only:
 - `default_task_pod_memory` (String) Deployment default task pod memory
 - `description` (String) Deployment description
 - `desired_dag_tarball_version` (String) Deployment desired DAG tarball version
+- `dr_workload_identity` (String) Deployment disaster recovery workload identity
 - `environment_variables` (Attributes Set) Deployment environment variables (see [below for nested schema](#nestedatt--deployments--environment_variables))
 - `executor` (String) Deployment executor. Allowed values: `CELERY`, `KUBERNETES`, `ASTRO`.
 - `external_ips` (Set of String) Deployment external IPs

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -227,6 +227,7 @@ resource "astro_deployment" "imported_deployment" {
 - `cluster_id` (String) Deployment cluster identifier - required for 'HYBRID' and 'DEDICATED' deployments. If changing this value, the deployment will be recreated in the new cluster
 - `default_task_pod_cpu` (String) Deployment default task pod CPU - required for 'STANDARD' and 'DEDICATED' deployments
 - `default_task_pod_memory` (String) Deployment default task pod memory - required for 'STANDARD' and 'DEDICATED' deployments
+- `desired_dr_workload_identity` (String) Deployment's desired disaster recovery workload identity. Only applies when the Deployment's cluster has Disaster Recovery enabled. The Terraform provider will use this provided workload identity to create the Deployment. If it is not provided the disaster recovery workload identity will be assigned automatically.
 - `desired_workload_identity` (String) Deployment's desired workload identity. The Terraform provider will use this provided workload identity to create the Deployment. If it is not provided the workload identity will be assigned automatically.
 - `is_development_mode` (Boolean) Deployment development mode - required for 'STANDARD' and 'DEDICATED' deployments. If changing from 'False' to 'True', the deployment will be recreated
 - `is_high_availability` (Boolean) Deployment high availability - required for 'STANDARD' and 'DEDICATED' deployments
@@ -250,6 +251,7 @@ resource "astro_deployment" "imported_deployment" {
 - `created_by` (Attributes) Deployment creator (see [below for nested schema](#nestedatt--created_by))
 - `dag_tarball_version` (String) Deployment DAG tarball version
 - `desired_dag_tarball_version` (String) Deployment desired DAG tarball version
+- `dr_workload_identity` (String) Deployment disaster recovery workload identity. Only set when the Deployment's cluster has Disaster Recovery enabled. This value can be changed via the Astro API if applicable.
 - `external_ips` (Set of String) Deployment external IPs
 - `id` (String) Deployment identifier
 - `image_repository` (String) Deployment image repository

--- a/internal/provider/models/deployment.go
+++ b/internal/provider/models/deployment.go
@@ -51,6 +51,8 @@ type DeploymentResource struct {
 	IsDagDeployEnabled          types.Bool   `tfsdk:"is_dag_deploy_enabled"`
 	DesiredWorkloadIdentity     types.String `tfsdk:"desired_workload_identity"`
 	WorkloadIdentity            types.String `tfsdk:"workload_identity"`
+	DesiredDrWorkloadIdentity   types.String `tfsdk:"desired_dr_workload_identity"`
+	DrWorkloadIdentity          types.String `tfsdk:"dr_workload_identity"`
 	ExternalIps                 types.Set    `tfsdk:"external_ips"`
 	OidcIssuerUrl               types.String `tfsdk:"oidc_issuer_url"`
 	WorkerQueues                types.Set    `tfsdk:"worker_queues"`
@@ -110,6 +112,7 @@ type DeploymentDataSource struct {
 	IsCicdEnforced           types.Bool   `tfsdk:"is_cicd_enforced"`
 	IsDagDeployEnabled       types.Bool   `tfsdk:"is_dag_deploy_enabled"`
 	WorkloadIdentity         types.String `tfsdk:"workload_identity"`
+	DrWorkloadIdentity       types.String `tfsdk:"dr_workload_identity"`
 	ExternalIps              types.Set    `tfsdk:"external_ips"`
 	OidcIssuerUrl            types.String `tfsdk:"oidc_issuer_url"`
 	WorkerQueues             types.Set    `tfsdk:"worker_queues"`
@@ -237,6 +240,7 @@ func (data *DeploymentResource) ReadFromResponse(
 	data.IsCicdEnforced = types.BoolValue(deployment.IsCicdEnforced)
 	data.IsDagDeployEnabled = types.BoolValue(deployment.IsDagDeployEnabled)
 	data.WorkloadIdentity = types.StringPointerValue(deployment.WorkloadIdentity)
+	data.DrWorkloadIdentity = types.StringPointerValue(deployment.DrWorkloadIdentity)
 	data.ExternalIps, diags = utils.StringSet(deployment.ExternalIPs)
 	if diags.HasError() {
 		return diags
@@ -340,6 +344,7 @@ func (data *DeploymentDataSource) ReadFromResponse(
 	data.IsCicdEnforced = types.BoolValue(deployment.IsCicdEnforced)
 	data.IsDagDeployEnabled = types.BoolValue(deployment.IsDagDeployEnabled)
 	data.WorkloadIdentity = types.StringPointerValue(deployment.WorkloadIdentity)
+	data.DrWorkloadIdentity = types.StringPointerValue(deployment.DrWorkloadIdentity)
 	data.ExternalIps, diags = utils.StringSet(deployment.ExternalIPs)
 	if diags.HasError() {
 		return diags

--- a/internal/provider/resources/resource_deployment.go
+++ b/internal/provider/resources/resource_deployment.go
@@ -107,6 +107,7 @@ func (r *DeploymentResource) Create(
 	}
 
 	desiredWorkloadIdentity := data.DesiredWorkloadIdentity.ValueString()
+	desiredDrWorkloadIdentity := data.DesiredDrWorkloadIdentity.ValueString()
 
 	switch data.Type.ValueString() {
 	case string(platform.DeploymentTypeSTANDARD):
@@ -131,6 +132,9 @@ func (r *DeploymentResource) Create(
 		}
 		if desiredWorkloadIdentity != "" {
 			createStandardDeploymentRequest.WorkloadIdentity = &desiredWorkloadIdentity
+		}
+		if desiredDrWorkloadIdentity != "" {
+			createStandardDeploymentRequest.DrWorkloadIdentity = &desiredDrWorkloadIdentity
 		}
 
 		// contact emails
@@ -194,6 +198,9 @@ func (r *DeploymentResource) Create(
 		}
 		if desiredWorkloadIdentity != "" {
 			createDedicatedDeploymentRequest.WorkloadIdentity = &desiredWorkloadIdentity
+		}
+		if desiredDrWorkloadIdentity != "" {
+			createDedicatedDeploymentRequest.DrWorkloadIdentity = &desiredDrWorkloadIdentity
 		}
 
 		// contact emails
@@ -263,6 +270,9 @@ func (r *DeploymentResource) Create(
 
 		if desiredWorkloadIdentity != "" {
 			createHybridDeploymentRequest.WorkloadIdentity = &desiredWorkloadIdentity
+		}
+		if desiredDrWorkloadIdentity != "" {
+			createHybridDeploymentRequest.DrWorkloadIdentity = &desiredDrWorkloadIdentity
 		}
 
 		// contact emails
@@ -406,6 +416,7 @@ func (r *DeploymentResource) Update(
 	var envVars []platform.DeploymentEnvironmentVariableRequest
 
 	desiredWorkloadIdentity := data.DesiredWorkloadIdentity.ValueString()
+	desiredDrWorkloadIdentity := data.DesiredDrWorkloadIdentity.ValueString()
 
 	switch data.Type.ValueString() {
 	case string(platform.DeploymentTypeSTANDARD):
@@ -428,6 +439,9 @@ func (r *DeploymentResource) Update(
 
 		if desiredWorkloadIdentity != "" {
 			updateStandardDeploymentRequest.WorkloadIdentity = &desiredWorkloadIdentity
+		}
+		if desiredDrWorkloadIdentity != "" {
+			updateStandardDeploymentRequest.DrWorkloadIdentity = &desiredDrWorkloadIdentity
 		}
 
 		// contact emails
@@ -490,6 +504,9 @@ func (r *DeploymentResource) Update(
 
 		if desiredWorkloadIdentity != "" {
 			updateDedicatedDeploymentRequest.WorkloadIdentity = &desiredWorkloadIdentity
+		}
+		if desiredDrWorkloadIdentity != "" {
+			updateDedicatedDeploymentRequest.DrWorkloadIdentity = &desiredDrWorkloadIdentity
 		}
 
 		// contact emails
@@ -557,6 +574,9 @@ func (r *DeploymentResource) Update(
 
 		if desiredWorkloadIdentity != "" {
 			updateHybridDeploymentRequest.WorkloadIdentity = &desiredWorkloadIdentity
+		}
+		if desiredDrWorkloadIdentity != "" {
+			updateHybridDeploymentRequest.DrWorkloadIdentity = &desiredDrWorkloadIdentity
 		}
 
 		// contact emails

--- a/internal/provider/schemas/deployment.go
+++ b/internal/provider/schemas/deployment.go
@@ -200,6 +200,14 @@ func DeploymentResourceSchemaAttributes() map[string]resourceSchema.Attribute {
 			MarkdownDescription: "Deployment workload identity. This value can be changed via the Astro API if applicable.",
 			Computed:            true,
 		},
+		"desired_dr_workload_identity": resourceSchema.StringAttribute{
+			MarkdownDescription: "Deployment's desired disaster recovery workload identity. Only applies when the Deployment's cluster has Disaster Recovery enabled. The Terraform provider will use this provided workload identity to create the Deployment. If it is not provided the disaster recovery workload identity will be assigned automatically.",
+			Optional:            true,
+		},
+		"dr_workload_identity": resourceSchema.StringAttribute{
+			MarkdownDescription: "Deployment disaster recovery workload identity. Only set when the Deployment's cluster has Disaster Recovery enabled. This value can be changed via the Astro API if applicable.",
+			Computed:            true,
+		},
 		"type": resourceSchema.StringAttribute{
 			MarkdownDescription: "Deployment type - if changing this value, the deployment will be recreated with the new type",
 			Required:            true,
@@ -523,6 +531,10 @@ func DeploymentDataSourceSchemaAttributes() map[string]datasourceSchema.Attribut
 		},
 		"workload_identity": datasourceSchema.StringAttribute{
 			MarkdownDescription: "Deployment workload identity",
+			Computed:            true,
+		},
+		"dr_workload_identity": datasourceSchema.StringAttribute{
+			MarkdownDescription: "Deployment disaster recovery workload identity",
 			Computed:            true,
 		},
 		"external_ips": datasourceSchema.SetAttribute{

--- a/internal/provider/schemas/deployment_test.go
+++ b/internal/provider/schemas/deployment_test.go
@@ -14,3 +14,42 @@ func TestDeploymentResourceSchemaAttributes_SchedulerAuIsOptionalAndComputed(t *
 	assert.True(t, schedulerAu.IsOptional(), "scheduler_au should be Optional")
 	assert.True(t, schedulerAu.IsComputed(), "scheduler_au should be Computed to avoid drift/inconsistent-result errors when omitted from config, e.g. after import")
 }
+
+func TestDeploymentResourceSchemaAttributes_DrWorkloadIdentity(t *testing.T) {
+	attributes := DeploymentResourceSchemaAttributes()
+
+	desired, ok := attributes["desired_dr_workload_identity"]
+	assert.True(t, ok, "desired_dr_workload_identity attribute should exist in the deployment resource schema")
+	assert.True(t, desired.IsOptional(), "desired_dr_workload_identity should be Optional, mirroring desired_workload_identity")
+	assert.False(t, desired.IsComputed(), "desired_dr_workload_identity should not be Computed, mirroring desired_workload_identity")
+
+	effective, ok := attributes["dr_workload_identity"]
+	assert.True(t, ok, "dr_workload_identity attribute should exist in the deployment resource schema")
+	assert.True(t, effective.IsComputed(), "dr_workload_identity should be Computed, mirroring workload_identity")
+	assert.False(t, effective.IsOptional(), "dr_workload_identity should not be Optional, mirroring workload_identity")
+}
+
+func TestDeploymentDataSourceSchemaAttributes_DrWorkloadIdentity(t *testing.T) {
+	attributes := DeploymentDataSourceSchemaAttributes()
+
+	effective, ok := attributes["dr_workload_identity"]
+	assert.True(t, ok, "dr_workload_identity attribute should exist in the deployment data source schema")
+	assert.True(t, effective.IsComputed(), "dr_workload_identity should be Computed")
+}
+
+// The deployments data source builds its objects from DeploymentsElementAttributeTypes, which has
+// to stay in step with the single-deployment data source schema. A key present in one and missing
+// from the other surfaces as a type mismatch at plan time rather than a compile error.
+func TestDeploymentsElementAttributeTypes_MatchesDeploymentDataSourceSchema(t *testing.T) {
+	schemaAttributes := DeploymentDataSourceSchemaAttributes()
+	elementTypes := DeploymentsElementAttributeTypes()
+
+	for name := range schemaAttributes {
+		_, ok := elementTypes[name]
+		assert.True(t, ok, "attribute %q is in the deployment data source schema but missing from DeploymentsElementAttributeTypes", name)
+	}
+	for name := range elementTypes {
+		_, ok := schemaAttributes[name]
+		assert.True(t, ok, "attribute %q is in DeploymentsElementAttributeTypes but missing from the deployment data source schema", name)
+	}
+}

--- a/internal/provider/schemas/deployments.go
+++ b/internal/provider/schemas/deployments.go
@@ -66,6 +66,7 @@ func DeploymentsElementAttributeTypes() map[string]attr.Type {
 		"is_high_availability":  types.BoolType,
 		"is_development_mode":   types.BoolType,
 		"workload_identity":     types.StringType,
+		"dr_workload_identity":  types.StringType,
 		"external_ips": types.SetType{
 			ElemType: types.StringType,
 		},


### PR DESCRIPTION
## What

Adds `desired_dr_workload_identity` (Optional) and `dr_workload_identity` (Computed) to `astro_deployment`, and exposes the effective DR identity on the `astro_deployment` and `astro_deployments` data sources.

## Why

A deployment on a DR-enabled cluster carries two workload identities, one per region. Harmony picks between them when rendering the deployment — `d.DRWorkloadIdentity` when `pc.IsDR`, `d.WorkloadIdentity` otherwise — and the Platform API accepts `drWorkloadIdentity` on create and update for standard, dedicated, and hybrid deployments. The provider only ever set the primary, so a Terraform-managed customer had to keep the primary identity in code and click the secondary into the UI.

This came out of a support ticket: a customer on a DR-enabled AWS cluster (`us-east-1` / `us-east-2`) had a customer-managed role on the primary and was still on the Astro default for the secondary, with no way to set it from Terraform.

## How

Mirrors the existing `desired_workload_identity` / `workload_identity` pair exactly — schema attributes, model fields, the mapping in both `ReadFromResponse` methods, and six guarded assignments (create/update × standard/dedicated/hybrid). The generated platform client already carried `DrWorkloadIdentity`; only the wiring was missing. Docs regenerated with `go generate ./...`.

## Testing

`go build`, `go vet`, `make validate-fmt` clean; `go test ./...` green across all 12 packages.

**No acceptance coverage.** Exercising this needs a DR-enabled cluster fixture the existing deployment tests don't have. The added unit tests cover the schema contract and keep `DeploymentsElementAttributeTypes` in step with the data source schema — verified by deliberately deleting the entry and confirming the test fails.

## For reviewers

As with the primary identity, the request field is set only when non-empty, so omitting it leaves the platform value unchanged. That means removing the attribute from HCL shows as a removal in the plan while the platform keeps the old value. This wart already exists for `desired_workload_identity`; flagging it in case you'd rather solve it for both at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
